### PR TITLE
Properly calculate divisors in rule-based number formatters

### DIFF
--- a/lib/CldrRbnfRuleSet.js
+++ b/lib/CldrRbnfRuleSet.js
@@ -52,7 +52,10 @@ CldrRbnfRuleSet.prototype = {
                         } else if (rule.value === '-x') {
                             expr = ['unary-prefix', '-', ['name', 'n']];
                         } else {
-                            expr = ['binary', '%', ['name', 'n'], ['num', parseInt(rule.value, 10)]];
+                            var radix = rule.radix || 10;
+                            var exp = Math.floor(Math.log(parseInt(rule.value)) / Math.log(radix));
+                            var divisor = exp >= 0 ? Math.pow(radix || 10, exp) : 1
+                            expr = ['binary', '%', ['name', 'n'], ['num', divisor]];
                         }
                     } else if (specialChar === '=') { // ==
                         expr = ['name', 'n'];


### PR DESCRIPTION
Currently in master, this code produces the wrong result:

``` js
var cldr = require("./lib/cldr");
var renderer = cldr.extractRbnfFunctionByType("en");
renderer.renderDigitsOrdinal(132);  // > "132th"
```

Clearly this should be "132nd" instead :)  This pull request fixes the problem by correctly calculating the divisor in the `if (specialChar)` code path.  From the [docs](http://grepcode.com/file/repo1.maven.org/maven2/com.ibm.icu/icu4j/3.4.4/com/ibm/icu/text/RuleBasedNumberFormat.java):

> ... To calculate the divisor, let the radix be 10, and the exponent be the highest exponent of the radix that yields a result less than or equal to the base value. ... If the exponent is positive or 0, the divisor is the radix raised to the power of the exponent; otherwise, the divisor is 1.

I've been working on a Ruby port of your excellent rule-based number formatter implementation - time to give back!
