### PR TITLE
Implement missing support for a number of missing cldr elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ synchronous loads, you can use `cldr.load(<arrayOfLocaleIds>, cb)` to
 load all the needed data in parallel before starting the extraction
 itself. Then all the needed documents will be loaded and ready.
 
+### cldr.extractLocaleDisplayPattern(localeId='root') ###
+
+Extract a locale display pattern hash for a locale:
+
+```javascript
+cldr.extractLocaleDisplayPattern('en_GB');
+{ localePattern: '{0} ({1})',
+  localeSeparator: '{0}, {1}',
+  localeKeyTypePattern: '{0}: {1}' }
+```
+
 ### cldr.extractLanguageDisplayNames(localeId='root') ###
 
 Extract a locale ID => display name hash for a locale:
@@ -149,7 +160,7 @@ cldr.extractTimeZoneFormats('da');
   gmtZero: 'GMT',
   region: 'Tidszone for {0}',
   fallback: '{1} ({0})',
-  fallbackRegion: 'Tidszone for {1} ({0})' }
+  regions: { daylight: '{0} (+1)', standard: '{0} (+0)' } }
 ```
 
 ### cldr.extractTerritoryDisplayNames(localeId='root') ###
@@ -181,6 +192,77 @@ Extract a script ID => display name hash for a locale:
 ```javascript
 cldr.extractScriptDisplayNames('en_US').Arab;
 'Arabic'
+```
+
+### cldr.extractKeyTypes(localeId='root') ###
+
+Extract keys and their associated types for a locale.
+
+```javascript
+cldr.extractKeyTypes('en').calendar;
+{ displayName: 'Calendar',
+  types: 
+   { buddhist: 'Buddhist Calendar',
+     chinese: 'Chinese Calendar',
+     coptic: 'Coptic Calendar',
+     dangi: 'Dangi Calendar',
+     ethiopic: 'Ethiopic Calendar',
+     ethiopicAmeteAlem: 'Ethiopic Amete Alem Calendar',
+     gregorian: 'Gregorian Calendar',
+     hebrew: 'Hebrew Calendar',
+     indian: 'Indian National Calendar',
+     islamic: 'Islamic Calendar',
+     islamicCivil: 'Islamic Calendar (tabular, civil epoch)',
+     islamicRgsa: 'Islamic Calendar (Saudi Arabia, sighting)',
+     islamicTbla: 'Islamic Calendar (tabular, astronomical epoch)',
+     islamicUmalqura: 'Islamic Calendar (Umm al-Qura)',
+     iso8601: 'ISO-8601 Calendar',
+     japanese: 'Japanese Calendar',
+     persian: 'Persian Calendar',
+     roc: 'Minguo Calendar' } }
+```
+
+```javascript
+cldr.extractKeyTypes('en').x;
+{ displayName: 'Private-Use' }
+```
+
+### cldr.extractTransformNames(localeId='root') ###
+
+Extract a hash of transform names for a locale.
+
+```javascript
+cldr.extractTransformNames('en');
+{ BGN: 'BGN',
+  Numeric: 'Numeric',
+  Tone: 'Tone',
+  UNGEGN: 'UNGEGN',
+  'x-Accents': 'Accents',
+  'x-Fullwidth': 'Fullwidth',
+  'x-Halfwidth': 'Halfwidth',
+  'x-Jamo': 'Jamo',
+  'x-Pinyin': 'Pinyin',
+  'x-Publishing': 'Publishing' }
+```
+
+### cldr.extractMeasurementSystemNames(localeId='root') ###
+
+Extract a hash of measurement system names for a locale.
+
+```javascript
+cldr.extractMeasurementSystemNames('en');
+{ metric: 'Metric', UK: 'UK', US: 'US' }
+```
+
+### cldr.extractCodePatterns(localeId='root') ###
+
+Extract a hash of code patterns for a locale.
+
+```javascript
+> cldr.extractCodePatterns('en');
+{ language: 'Language: {0}',
+  script: 'Script: {0}',
+  territory: 'Region: {0}' }
 ```
 
 ### cldr.extractEraNames(localeId='root', calendarId='gregorian') ###

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -6,6 +6,7 @@ var Path = require('path'),
     libxmljs = require('libxmljs'),
     seq = require('seq'),
     normalizeLocaleId = require('./normalizeLocaleId'),
+    normalizeProperty = require('./normalizeProperty'),
     convertObjectsWithIntegerKeysToArrays = require('./convertObjectsWithIntegerKeysToArrays'),
     CldrPluralRuleSet = require('./CldrPluralRuleSet'),
     CldrRbnfRuleSet = require('./CldrRbnfRuleSet'),
@@ -202,6 +203,15 @@ Cldr.prototype = {
         };
     },
 
+    extractLocaleDisplayPattern: function (localeId) {
+        var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
+            localeDisplayPattern = {};
+        finder("/ldml/localeDisplayNames/localeDisplayPattern/*").forEach(function (node) {
+            localeDisplayPattern[node.name()] = node.text();
+        });
+        return localeDisplayPattern;
+    },
+
     extractLanguageDisplayNames: function (localeId) {
         var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
             languageDisplayNames = {};
@@ -251,6 +261,11 @@ Cldr.prototype = {
                 }
                 timeZoneFormats[formatName] = timeZoneFormats[formatName] || value;
             });
+        });
+        finder("/ldml/dates/timeZoneNames/regionFormat[@type]").forEach(function (node) {
+            var type = node.attr('type').value();
+            timeZoneFormats.regions = timeZoneFormats.regions || {};
+            timeZoneFormats.regions[type] = timeZoneFormats.regions[type] || node.text();
         });
         return timeZoneFormats;
     },
@@ -307,6 +322,53 @@ Cldr.prototype = {
         return scriptDisplayNames;
     },
 
+    extractKeyTypes: function (localeId) {
+        var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
+            keyTypes = {};
+        finder('/ldml/localeDisplayNames/keys/key').forEach(function (keyNode) {
+            var type = keyNode.attr('type').value();
+            keyTypes[type] = { displayName: keyNode.text() };
+        });
+        finder('/ldml/localeDisplayNames/types/type').forEach(function (typeNode) {
+            var key = typeNode.attr('key').value(),
+                type = normalizeProperty(typeNode.attr('type').value());
+            keyTypes[key] = keyTypes[key] || {};
+            keyTypes[key].types = keyTypes[key].types || {};
+            keyTypes[key].types[type] = typeNode.text();
+        });
+        return keyTypes;
+    },
+
+    extractTransformNames: function (localeId) {
+        var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
+            transformNames = {};
+        finder("/ldml/localeDisplayNames/transformNames/transformName").forEach(function (transformNameNode) {
+            var id = transformNameNode.attr('type').value();
+            transformNames[id] = transformNames[id] || transformNameNode.text();
+        });
+        return transformNames;
+    },
+
+    extractMeasurementSystemNames: function (localeId) {
+        var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
+            measurementSystemNames = {};
+        finder("/ldml/localeDisplayNames/measurementSystemNames/measurementSystemName").forEach(function (measurementSystemNameNode) {
+            var id = measurementSystemNameNode.attr('type').value();
+            measurementSystemNames[id] = measurementSystemNames[id] || measurementSystemNameNode.text();
+        });
+        return measurementSystemNames;
+    },
+
+    extractCodePatterns: function (localeId) {
+        var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
+            codePatterns = {};
+        finder("/ldml/localeDisplayNames/codePatterns/codePattern").forEach(function (codePatternNode) {
+            var id = codePatternNode.attr('type').value();
+            codePatterns[id] = codePatterns[id] || codePatternNode.text();
+        });
+        return codePatterns;
+    },
+
     // Calendar extraction methods:
 
     extractEraNames: function (localeId, calendarId) {
@@ -330,9 +392,7 @@ Cldr.prototype = {
         var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
             quarterNames;
         ['format', 'stand-alone'].forEach(function (quarterContext) {
-            var quarterContextCamelCase = quarterContext.replace(/-([a-z])/g, function ($0, ch) { // stand-alone => standAlone
-                return ch.toUpperCase();
-            });
+            var quarterContextCamelCase = normalizeProperty(quarterContext); // stand-alone => standAlone
             ['abbreviated', 'narrow', 'wide'].forEach(function (quarterWidth) {
                 finder("/ldml/dates/calendars/calendar[@type='" + calendarId + "']/quarters/quarterContext[@type='" + quarterContext + "']/quarterWidth[@type='" + quarterWidth + "']/quarter").forEach(function (quarterNode) {
                     var quarterNo = parseInt(quarterNode.attr('type').value(), 10) - 1;
@@ -352,9 +412,7 @@ Cldr.prototype = {
         var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
             dayPeriods;
         ['format', 'stand-alone'].forEach(function (dayPeriodContext) {
-            var dayPeriodContextCamelCase = dayPeriodContext.replace(/-([a-z])/g, function ($0, ch) { // stand-alone => standAlone
-                return ch.toUpperCase();
-            });
+            var dayPeriodContextCamelCase = normalizeProperty(dayPeriodContext); // stand-alone => standAlone
             ['abbreviated', 'narrow', 'wide', 'short'].forEach(function (dayPeriodWidth) {
                 finder("/ldml/dates/calendars/calendar[@type='" + calendarId + "']/dayPeriods/dayPeriodContext[@type='" + dayPeriodContext + "']/dayPeriodWidth[@type='" + dayPeriodWidth + "']/dayPeriod").forEach(function (dayPeriodNode) {
                     var type = dayPeriodNode.attr('type').value();
@@ -397,9 +455,7 @@ Cldr.prototype = {
         var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
             monthNames;
         ['format', 'stand-alone'].forEach(function (monthContext) {
-            var monthContextCamelCase = monthContext.replace(/-([a-z])/g, function ($0, ch) { // stand-alone => standAlone
-                return ch.toUpperCase();
-            });
+            var monthContextCamelCase = normalizeProperty(monthContext); // stand-alone => standAlone
             ['abbreviated', 'narrow', 'wide'].forEach(function (monthWidth) {
                 finder("/ldml/dates/calendars/calendar[@type='" + calendarId + "']/months/monthContext[@type='" + monthContext + "']/monthWidth[@type='" + monthWidth + "']/month").forEach(function (monthNode) {
                     var monthNo = parseInt(monthNode.attr('type').value(), 10) - 1;
@@ -419,9 +475,7 @@ Cldr.prototype = {
         var finder = this.createFinder(this.getPrioritizedDocumentsForLocale(localeId, 'main')),
             monthPatterns;
         ['format', 'numeric', 'stand-alone'].forEach(function (monthPatternContext) {
-            var monthPatternContextCamelCase = monthPatternContext.replace(/-([a-z])/g, function ($0, ch) { // stand-alone => standAlone
-                return ch.toUpperCase();
-            });
+            var monthPatternContextCamelCase = normalizeProperty(monthPatternContext); // stand-alone => standAlone
             ['abbreviated', 'narrow', 'wide', 'all'].forEach(function (monthPatternWidth) {
                 finder("/ldml/dates/calendars/calendar[@type='" + calendarId + "']/monthPatterns/monthPatternContext[@type='" + monthPatternContext + "']/monthPatternWidth[@type='" + monthPatternWidth + "']/monthPattern").forEach(function (monthPatternNode) {
                     var type = monthPatternNode.attr('type').value();
@@ -443,9 +497,7 @@ Cldr.prototype = {
             dayNoByCldrId = {sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6},
             dayNames;
         ['format', 'numeric', 'stand-alone'].forEach(function (dayContext) {
-            var dayContextCamelCase = dayContext.replace(/-([a-z])/g, function ($0, ch) { // stand-alone => standAlone
-                return ch.toUpperCase();
-            });
+            var dayContextCamelCase = normalizeProperty(dayContext); // stand-alone => standAlone
             ['abbreviated', 'narrow', 'wide', 'short'].forEach(function (dayWidth) {
                 finder("/ldml/dates/calendars/calendar[@type='" + calendarId + "']/days/dayContext[@type='" + dayContext + "']/dayWidth[@type='" + dayWidth + "']/day").forEach(function (dayNode) {
                     var dayNo = dayNoByCldrId[dayNode.attr('type').value()];
@@ -636,9 +688,7 @@ Cldr.prototype = {
             var unitNode = unitPatternNode.parent(),
                 unitLengthNode = unitNode.parent(),
                 unitLength = unitLengthNode.attr('type').value(),
-                unitId = unitNode.attr('type').value().replace(/-([a-z])/g, function ($0, ch) { // year-future => yearFuture etc.
-                return ch.toUpperCase();
-            });
+                unitId = normalizeProperty(unitNode.attr('type').value()); // year-future => yearFuture etc.
             unitPatterns.unit[unitLength] = unitPatterns.unit[unitLength] || {};
             unitPatterns.unit[unitLength][unitId] = unitPatterns.unit[unitLength][unitId] || {};
             var count = unitPatternNode.attr('count').value();

--- a/lib/normalizeProperty.js
+++ b/lib/normalizeProperty.js
@@ -1,0 +1,8 @@
+/*
+ * Convert foo-bar attribute values to fooBar JavaScript keys
+ */
+module.exports = function normalizeProperty(str) {
+	return str.replace(/-([a-z])/g, function ($0, ch) {
+        return ch.toUpperCase();
+    });
+};

--- a/test/extractCodePatterns.js
+++ b/test/extractCodePatterns.js
@@ -1,0 +1,12 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractCodePatterns', function () {
+    it('should extract the British English code patterns correctly', function () {
+		var britishCodePatterns = cldr.extractCodePatterns('en_GB');
+        expect(britishCodePatterns, 'to only have keys', ['language', 'script', 'territory']);
+        expect(britishCodePatterns.language, 'to equal', 'Language: {0}');
+        expect(britishCodePatterns.script, 'to equal', 'Script: {0}');
+        expect(britishCodePatterns.territory, 'to equal', 'Region: {0}');
+    });
+});

--- a/test/extractFields.js
+++ b/test/extractFields.js
@@ -3,7 +3,7 @@ var expect = require('unexpected'),
 
 describe('extractFields', function () {
     it('should extract the British English fields correctly', function () {
-		var britishFields = cldr.extractFields('en_GB');
+        var britishFields = cldr.extractFields('en_GB');
         expect(britishFields, 'to only have keys', ['dayperiod', 'era', 'year', 'month', 'week', 'day', 'weekday', 'hour', 'minute', 'second', 'zone', 'sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']);
         expect(britishFields.dayperiod, 'to equal', {displayName: 'am/pm'});
         expect(britishFields.sat, 'to equal', {

--- a/test/extractKeyTypes.js
+++ b/test/extractKeyTypes.js
@@ -1,0 +1,18 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractKeyTypes', function () {
+    it('should extract the British English keys and types correctly', function () {
+        var britishKeyTypes = cldr.extractKeyTypes('en_GB');
+        // Just name a few of the keys
+        expect(britishKeyTypes, 'to have keys', ['calendar', 'colNumeric', 'numbers', 'timezone', 'x']);
+        expect(britishKeyTypes.x, 'to only have keys', ['displayName']);
+        expect(britishKeyTypes.x.displayName, 'to equal', 'Private-Use');
+        expect(britishKeyTypes.colNumeric, 'to only have keys', ['displayName', 'types']);
+        expect(britishKeyTypes.colNumeric, 'to only have keys', ['displayName', 'types']);
+        expect(britishKeyTypes.colNumeric.displayName, 'to equal', 'Numeric Sorting');
+        expect(britishKeyTypes.colNumeric.types, 'to only have keys', ['no', 'yes']);
+        expect(britishKeyTypes.colNumeric.types.no, 'to equal', 'Sort Digits Individually');
+        expect(britishKeyTypes.colNumeric.types.yes, 'to equal', 'Sort Digits Numerically');
+    });
+});

--- a/test/extractListPatterns.js
+++ b/test/extractListPatterns.js
@@ -3,7 +3,7 @@ var expect = require('unexpected'),
 
 describe('extractListPatterns', function () {
     it('should extract the British English list patterns correctly', function () {
-		var britishListPatterns = cldr.extractListPatterns('en_GB');
+        var britishListPatterns = cldr.extractListPatterns('en_GB');
         expect(britishListPatterns, 'to only have keys', ['default', 'unit', 'unit-narrow', 'unit-short']);
         expect(britishListPatterns.default, 'to equal', {
             2: '{0} and {1}',

--- a/test/extractLocaleDisplayPattern.js
+++ b/test/extractLocaleDisplayPattern.js
@@ -1,0 +1,12 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractLocaleDisplayPattern', function () {
+    it('should extract the British English patterns correctly', function () {
+        var britishLocaleDisplayPatterns = cldr.extractLocaleDisplayPattern('en_GB');
+        expect(britishLocaleDisplayPatterns, 'to only have keys', ['localePattern', 'localeSeparator', 'localeKeyTypePattern']);
+        expect(britishLocaleDisplayPatterns.localePattern, 'to equal', '{0} ({1})');
+        expect(britishLocaleDisplayPatterns.localeSeparator, 'to equal', '{0}, {1}');
+        expect(britishLocaleDisplayPatterns.localeKeyTypePattern, 'to equal', '{0}: {1}');
+    });
+});

--- a/test/extractMeasurementSystemNames.js
+++ b/test/extractMeasurementSystemNames.js
@@ -1,0 +1,12 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractMeasurementSystemNames', function () {
+    it('should extract the British English measurement systems correctly', function () {
+        var britishMeasurementSystemNames = cldr.extractMeasurementSystemNames('en_GB');
+        expect(britishMeasurementSystemNames, 'to only have keys', ['metric', 'UK', 'US']);
+        expect(britishMeasurementSystemNames.metric, 'to equal', 'Metric');
+        expect(britishMeasurementSystemNames.UK, 'to equal', 'UK');
+        expect(britishMeasurementSystemNames.US, 'to equal', 'US');
+    });
+});

--- a/test/extractTimeZoneFormats.js
+++ b/test/extractTimeZoneFormats.js
@@ -1,0 +1,17 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractTimeZoneFormats', function () {
+    it('should extract the British English patterns correctly', function () {
+        var britishTimeZoneFormats = cldr.extractTimeZoneFormats('en_GB');
+        expect(britishTimeZoneFormats, 'to only have keys', ['hour', 'gmt', 'gmtZero', 'region', 'fallback', 'regions']);
+        expect(britishTimeZoneFormats.hour, 'to equal', ['+HH:mm', '-HH:mm']);
+        expect(britishTimeZoneFormats.gmt, 'to equal', 'GMT{0}');
+        expect(britishTimeZoneFormats.gmtZero, 'to equal', 'GMT');
+        expect(britishTimeZoneFormats.region, 'to equal', '{0} Time');
+        expect(britishTimeZoneFormats.fallback, 'to equal', '{1} ({0})');
+        expect(britishTimeZoneFormats.regions, 'to only have keys', ['daylight', 'standard']);
+        expect(britishTimeZoneFormats.regions.daylight, 'to equal', '{0} Daylight Time');
+        expect(britishTimeZoneFormats.regions.standard, 'to equal', '{0} Standard Time');
+    });
+});

--- a/test/extractTransformNames.js
+++ b/test/extractTransformNames.js
@@ -1,0 +1,13 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractTransformNames', function () {
+    it('should extract the British English transform names correctly', function () {
+        var britishTransformNames = cldr.extractTransformNames('en_GB');
+        // Just name a few of the keys
+        expect(britishTransformNames, 'to have keys', ['BGN', 'Numeric', 'x-Fullwidth']);
+        expect(britishTransformNames.BGN, 'to equal', 'BGN');
+        expect(britishTransformNames.Numeric, 'to equal', 'Numeric');
+        expect(britishTransformNames['x-Fullwidth'], 'to equal', 'Fullwidth');
+    });
+});

--- a/test/extractUnitPatterns.js
+++ b/test/extractUnitPatterns.js
@@ -3,7 +3,7 @@ var expect = require('unexpected'),
 
 describe('extractUnitPatterns', function () {
     it('should extract the British English patterns correctly', function () {
-		var britishUnitPatterns = cldr.extractUnitPatterns('en_GB');
+        var britishUnitPatterns = cldr.extractUnitPatterns('en_GB');
         expect(britishUnitPatterns, 'to only have keys', ['unit', 'compoundUnit']);
         expect(britishUnitPatterns.unit, 'to only have keys', ['long', 'short', 'narrow']);
         expect(britishUnitPatterns.unit.long, 'to have keys', ['angleArcSecond', 'volumeLiter']);


### PR DESCRIPTION
Add a number of methods covering parts of cldr’s main .xml files that weren’t supported before.
- extractLocaleDisplayPattern that covers /ldml/localeDisplayNames/localeDisplayPattern/*
- extractKeyTypes that covers /ldml/localeDisplayNames/keys/key and /ldml/localeDisplayNames/types/type.
- extractTransformNames that covers /ldml/localeDisplayNames/transformNames/transformName.
- extractMeasurementSystemNames that covers /ldml/localeDisplayNames/measurementSystemNames/measurementSystemName.
- extractCodePatterns that covers /ldml/localeDisplayNames/codePatterns/codePattern.

Also make some modifications:
- Expand extractTimeZoneFormats to contain a regions object with the daylight and standard types of regionFormat elements.
- Put all the foo-bar -> fooBar code into a normalizeProperty function.
- Add tests for all the cldr functions added or modified.
- Do a tiny bit of tabs -> spaces changes in the tests.
