### PR TITLE
Better ends-with implementation

### DIFF
--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -759,7 +759,7 @@ Cldr.prototype = {
                     "@locales = '" + subLocaleId + "' or " +
                     "starts-with(@locales, '" + subLocaleId + "') or " +
                     "contains(@locales, ' " + subLocaleId + " ') or " +
-                    "(contains(@locales, ' " + subLocaleId + "') and substring-after(@locales, ' " + subLocaleId + "') = '')",
+                    "substring(@locales, string-length(@locales) - string-length(' " + subLocaleId + "') + 1) = ' " + subLocaleId + "'",
                 pluralRulesNodes = xpath.select("/supplementalData/plurals/pluralRules[" + matchLocalesXPathExpr + "]", document),
                 cldrPluralRuleSet = new CldrPluralRuleSet();
             if (pluralRulesNodes.length > 0) {


### PR DESCRIPTION
The current XPath expression does not correctly match trailing attribute values. For example this one:

``` xml
<pluralRules locales="mo ro">
```

The result is that it (quietly) generates plural functions with empty body for `ro`. Not in scope here - but would it be possible to either fail or generate a function that fails (throws) for unsupported locales?
- Based on [this post on stackoverflow](http://stackoverflow.com/a/22437888)
- Fixes #20
