### PR TITLE
Specify the BSD-3-Clause license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "units"
   ],
   "author": "Andreas Lind Petersen <andreas@one.com>",
-  "license": "BSD"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
NPM thinks the BSD-2-Clause is the intended one:
https://www.npmjs.com/package/cldr