### PR TITLE
Added support for extracting language supplemental data

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,23 @@ cldr.extractDigitsByNumberSystemId();
   [...] }
 ```
 
+
+### cldr.extractLanguageSupplementalData() ###
+
+Extract supplemental data for languages. These data contain a list of
+territories where the language is spoken, and scripts that are used
+with the language. Both territories and scripts can be either primary
+or secondary for the language.
+
+```javascript
+{ ar:
+  { scripts: [ 'Arab' ], territories: [ 'AE', 'BH', [...] ],
+    secondary: {
+      scripts: [ 'Syrc' ], territories: [ 'IR', 'SS' ] }
+  },
+  [...] }
+```
+
 License
 -------
 

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -979,6 +979,38 @@ Cldr.prototype = {
         });
 
         return territoryContainmentGroups;
+    },
+
+    extractLanguageSupplementalData: function () {
+        var finder = this.createFinder([this.getDocument(Path.resolve(this.cldrPath, 'common', 'supplemental', 'supplementalData.xml'))]);
+
+        var languageData = {};
+
+        finder('/supplementalData/languageData/language').forEach(function (languageNode) {
+            var type = languageNode.getAttribute('type');
+            var isSecondary = languageNode.getAttribute('alt') === 'secondary';
+            var record;
+
+            if (!languageData[type]) {
+                languageData[type] = record = {};
+            }
+
+            if (isSecondary) {
+                languageData[type].secondary = record = {};
+            }
+
+            var scriptsAttr = languageNode.getAttribute('scripts');
+            if (scriptsAttr) {
+                record.scripts = scriptsAttr.split(' ');
+            }
+
+            var territoriesAttr = languageNode.getAttribute('territories');
+            if (territoriesAttr) {
+                record.territories = territoriesAttr.split(' ');
+            }
+        });
+
+        return languageData;
     }
 };
 

--- a/test/extractLanguageSupplementalData.js
+++ b/test/extractLanguageSupplementalData.js
@@ -1,0 +1,47 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractLanguageSupplementalData', function () {
+    it('should return an object with locale ids as keys and objects as values', function () {
+        expect(cldr.extractLanguageSupplementalData(), 'to satisfy', {
+            en: {},
+            fr: {}
+        });
+    });
+
+    it('should return a list of scripts for English', function () {
+        expect(cldr.extractLanguageSupplementalData(), 'to satisfy', {
+            en: {
+                scripts: [ 'Latn' ]
+            }
+        });
+    });
+
+    it('should return a list of territories for English', function () {
+        expect(cldr.extractLanguageSupplementalData(), 'to satisfy', {
+            en: {
+                territories: expect.it('to contain', 'GB', 'US')
+            }
+        });
+    });
+
+    it('should return a list of secondary scripts for English', function () {
+        expect(cldr.extractLanguageSupplementalData(), 'to satisfy', {
+            en: {
+                secondary: {
+                    scripts: [ 'Dsrt', 'Shaw' ]
+                }
+            }
+        });
+    });
+
+    it('should return a list of secondary territories for English', function () {
+        expect(cldr.extractLanguageSupplementalData(), 'to satisfy', {
+            en: {
+                secondary: {
+                    territories: expect.it('to contain', 'CZ', 'DE')
+                }
+            }
+        });
+    });
+});


### PR DESCRIPTION
Added method `extractLanguageSupplementalData` that extracts language
supplemental data from `common/supplemental/supplementalData.xml`.

My use case for this method was having a list of languages as input
and needing to group these languages according to territories where
they are spoken (Europe, Africa, Asia, ...)