### PR TITLE
Add function to extract language metadata

### DIFF
--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1078,6 +1078,22 @@ Cldr.prototype = {
         });
 
         return languageData;
+    },
+
+    extractLanguageSupplementalMetadata: function () {
+        var finder = this.createFinder([this.getDocument(Path.resolve(this.cldrPath, 'common', 'supplemental', 'supplementalMetadata.xml'))]);
+
+        var languageData = {};
+
+        finder('/supplementalData/metadata/alias/languageAlias').forEach(function (languageAliasNode) {
+            var type = languageAliasNode.getAttribute('type');
+            languageData[type] = {
+                replacement: languageAliasNode.getAttribute('replacement'),
+                reason: languageAliasNode.getAttribute('reason')
+            };
+        });
+
+        return languageData;
     }
 };
 

--- a/test/extractLanguageSupplementalMetadata.js
+++ b/test/extractLanguageSupplementalMetadata.js
@@ -1,0 +1,21 @@
+var expect = require('unexpected'),
+    cldr = require('../lib/cldr');
+
+describe('extractLanguageSupplementalMetadata', function () {
+    it('should return an object with locale ids as keys and objects as values', function () {
+        expect(cldr.extractLanguageSupplementalMetadata(), 'to satisfy', {
+            no: {},
+            glv: {}
+        });
+    });
+    it('should return a reason', function () {
+        expect(cldr.extractLanguageSupplementalMetadata(), 'to satisfy', {
+            no: { replacement: 'nb' },
+        });
+    });
+    it('should return a replacement', function () {
+        expect(cldr.extractLanguageSupplementalMetadata(), 'to satisfy', {
+            no: { reason: 'legacy' },
+        });
+    });
+});

--- a/test/extractLanguageSupplementalMetadata.js
+++ b/test/extractLanguageSupplementalMetadata.js
@@ -10,12 +10,12 @@ describe('extractLanguageSupplementalMetadata', function () {
     });
     it('should return a reason', function () {
         expect(cldr.extractLanguageSupplementalMetadata(), 'to satisfy', {
-            no: { replacement: 'nb' },
+            no: { replacement: 'nb' }
         });
     });
     it('should return a replacement', function () {
         expect(cldr.extractLanguageSupplementalMetadata(), 'to satisfy', {
-            no: { reason: 'legacy' },
+            no: { reason: 'legacy' }
         });
     });
 });


### PR DESCRIPTION
First of all, thanks for providing this library! 🏆

We are using it to generate language information to use in our frontend. We noticed that our backend allows some language tags that CLDR doesn't contain. After some investigation we found out that those language tags are considered "legacy" and thus not included in the standard set 😱. They are, however, included in the supplemental metadata file, which can be used to map outdated tags to their respective replacements.

Since there was no function to extract that supplemental metadata we went ahead and added it. We also made sure to include tests in the same manner as the supplemental data has tests.

We hope the addition makes sense. In case there are any concerns with the code we are happy to address those 😊