### PR TITLE
make high code points digits work

### DIFF
--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1538,7 +1538,7 @@ Cldr.prototype = {
     if (type === 'numeric') {
       numberingSystem.digits = numberingSystemNode
         .getAttribute('digits')
-        .split(/(?:)/);
+        .split(/(?:)/u);
     } else {
       // type='algorithmic'
       const rulesAttributeFragments = numberingSystemNode
@@ -1576,7 +1576,7 @@ Cldr.prototype = {
         if (numberingSystemNode.getAttribute('type') === 'numeric') {
           digitsByNumberSystemId[
             numberSystemId
-          ] = numberingSystemNode.getAttribute('digits').split(/(?:)/);
+          ] = numberingSystemNode.getAttribute('digits').split(/(?:)/u);
         } else {
           // type='algorithmic'
           const rulesAttributeFragments = numberingSystemNode

--- a/test/extractNumberingSystem.js
+++ b/test/extractNumberingSystem.js
@@ -18,6 +18,13 @@ describe('extractNumberingSystem', () => {
     });
   });
 
+  it('should extract digits with high codepoints', () => {
+    expect(cldr.extractNumberingSystem('ahom'), 'to equal', {
+      type: 'numeric',
+      digits: ['𑜰', '𑜱', '𑜲', '𑜳', '𑜴', '𑜵', '𑜶', '𑜷', '𑜸', '𑜹']
+    });
+  });
+
   it('should extract an algorithmic numbering system without a locale', () => {
     expect(cldr.extractNumberingSystem('ethi'), 'to equal', {
       type: 'algorithmic',


### PR DESCRIPTION
This pull request fixes a bug where `extractNumberingSystem()` does not work for some scripts that use surrogate pairs for storing digits, e.g:

```
cldr.extractNumberingSystem("ahom").digits
// [ '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�', '�' ]
//Expected: [ '𑜰', '𑜱', '𑜲', '𑜳', '𑜴', '𑜵', '𑜶', '𑜷', '𑜸', '𑜹' ]
```
See also: https://stackoverflow.com/questions/4547609/how-do-you-get-a-string-to-a-character-array-in-javascript/34717402#34717402

Note that this pull request works by adding the ES2015 `/u` flag to the regular expression. Not sure if that's acceptable for this lib.

Alternatives to using a regex (`digits.split(/(?:)/u)`) would be `[...digits]` or `Array.from(digits)` (see the Stack Overflow thread linked above), but they too are ES2015, of course.