### PR TITLE
Subregions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ cldr.extractLanguageDisplayNames('it').en;
 ('inglese');
 ```
 
-### cldr.extractSubdivisionDisplayNames(localeId='root')
+### cldr.extractSubdivisionDisplayNames(localeId)
 
 Extract a subnational territory ID => display name hash for a locale.
 For global regions and countries, see [extractTerritoryDisplayNames](#cldrextractterritorydisplaynameslocaleidroot)
@@ -241,7 +241,7 @@ cldr.extractTimeZoneFormats('da');
   regions: { daylight: '{0} (+1)', standard: '{0} (+0)' } }
 ```
 
-### cldr.extractTerritoryDisplayNames(localeId='root')
+### cldr.extractTerritoryDisplayNames(localeId)
 
 Extract a territory ID => display name hash for a locale.
 This method will return global regions and countries. For subnational

--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ cldr.extractLanguageDisplayNames('it').en;
 ### cldr.extractSubdivisionDisplayNames(localeId)
 
 Extract a subnational territory ID => display name hash for a locale.
+Codes follow the BCP47 standard, e.g. `usca` for California, USA.
+Note that these codes are similar but not identical to ISO 3166-2 codes. Unlike ISO 3166-2, CLDR never reuses a code.
+
 For global regions and countries, see [extractTerritoryDisplayNames](#cldrextractterritorydisplaynameslocaleidroot)
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Note that these codes are similar but not identical to ISO 3166-2 codes. Unlike 
 For global regions and countries, see [extractTerritoryDisplayNames](#cldrextractterritorydisplaynameslocaleidroot)
 
 ```javascript
- cldr.extractSubdivisionDisplayNames('en').dk85
+cldr.extractSubdivisionDisplayNames('en').dk85;
 ('Zealand');
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ cldr.extractLanguageDisplayNames('it').en;
 ('inglese');
 ```
 
+### cldr.extractSubdivisionDisplayNames(localeId='root')
+
+Extract a subnational territory ID => display name hash for a locale.
+For global regions and countries, see [extractTerritoryDisplayNames](#cldrextractterritorydisplaynameslocaleidroot)
+
+```javascript
+ cldr.extractSubdivisionDisplayNames('en').dk85
+('Zealand');
+```
+
 ### cldr.extractTimeZoneDisplayNames(localeId='root')
 
 Extract a time zone ID (Olson) => display name hash for a locale:
@@ -233,7 +243,9 @@ cldr.extractTimeZoneFormats('da');
 
 ### cldr.extractTerritoryDisplayNames(localeId='root')
 
-Extract a territory ID => display name hash for a locale:
+Extract a territory ID => display name hash for a locale.
+This method will return global regions and countries. For subnational
+divisions, see [extractSubdivisionDisplayNames](#cldrextractsubdivisiondisplaynameslocaleidroot).
 
 ```javascript
 cldr.extractTerritoryDisplayNames('fr').US;

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -40,39 +40,39 @@ function Cldr(cldrPath) {
 }
 
 Cldr.prototype = {
-  get fileNamesByTypeAndNormalizedLocaleId() {
+  fileNamesByTypeAndNormalizedLocaleId(type='main') {
     if (!this._fileNamesByTypeAndNormalizedLocaleId) {
       this._fileNamesByTypeAndNormalizedLocaleId = {};
-      ['main', 'rbnf'].forEach(function(type) {
-        this._fileNamesByTypeAndNormalizedLocaleId[type] = {};
-        let fileNames;
-        try {
-          fileNames = fs.readdirSync(
-            Path.resolve(this.cldrPath, 'common', type)
-          );
-        } catch (e) {
-          if (e.code === 'ENOENT') {
-            // Directory doesn't exist, just pretend it's empty.
-            return;
-          }
+    }
+    if (typeof this._fileNamesByTypeAndNormalizedLocaleId[type] === "undefined") {
+      this._fileNamesByTypeAndNormalizedLocaleId[type] = {};
+      let fileNames;
+      try {
+        fileNames = fs.readdirSync(
+          Path.resolve(this.cldrPath, 'common', type)
+        );
+      } catch (e) {
+        if (e.code === 'ENOENT') {
+          // Directory doesn't exist, just pretend it's empty.
+          return;
         }
-        fileNames.forEach(function(fileName) {
-          const matchFileName = fileName.match(/^(.*)\.xml$/);
-          if (matchFileName) {
-            this._fileNamesByTypeAndNormalizedLocaleId[type][
-              normalizeLocaleId(matchFileName[1])
-            ] = Path.resolve(this.cldrPath, 'common', type, fileName);
-          }
-        }, this);
+      }
+      fileNames.forEach(function(fileName) {
+        const matchFileName = fileName.match(/^(.*)\.xml$/);
+        if (matchFileName) {
+          this._fileNamesByTypeAndNormalizedLocaleId[type][
+            normalizeLocaleId(matchFileName[1])
+          ] = Path.resolve(this.cldrPath, 'common', type, fileName);
+        }
       }, this);
     }
-    return this._fileNamesByTypeAndNormalizedLocaleId;
+    return this._fileNamesByTypeAndNormalizedLocaleId[type];
   },
 
   get localeIds() {
     if (!this._localeIds) {
       this._localeIds = Object.keys(
-        this.fileNamesByTypeAndNormalizedLocaleId.main
+        this.fileNamesByTypeAndNormalizedLocaleId("main")
       );
     }
     return this._localeIds;
@@ -282,7 +282,7 @@ Cldr.prototype = {
       .concat('root')
       .map(
         subLocaleId =>
-          that.fileNamesByTypeAndNormalizedLocaleId[type][
+          that.fileNamesByTypeAndNormalizedLocaleId(type)[
             normalizeLocaleId(subLocaleId)
           ]
       )
@@ -317,7 +317,7 @@ Cldr.prototype = {
     Object.keys(neededLocaleById).forEach(localeId => {
       ['main', 'rbnf'].forEach(type => {
         const fileName =
-          that.fileNamesByTypeAndNormalizedLocaleId[type][localeId];
+          that.fileNamesByTypeAndNormalizedLocaleId(type)[localeId];
         if (fileName) {
           fileNames.push(fileName);
         }

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -496,7 +496,7 @@ Cldr.prototype = {
    * Note that these codes are similar but not identical to ISO 3166-2 codes.
    * Unlike ISO 3166-2, CLDR never reuses a code.
    *
-   * @param {string} [localeId='root'] Locale or subdivision names
+   * @param {string} localeId Locale or subdivision names
    * @returns {Object} A dictionary of subdivision codes and their names.
    *
    * @example

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -490,6 +490,21 @@ Cldr.prototype = {
     return territoryDisplayNames;
   },
 
+  extractSubdivisionDisplayNames(localeId) {
+    this.checkValidLocaleId(localeId);
+    const finder = this.createFinder(
+      this.getPrioritizedDocumentsForLocale(localeId, 'subdivisions')
+    );
+    const subdivisionDisplayNames = {};
+    finder('/ldml/localeDisplayNames/subdivisions/subdivision').forEach(node => {
+      if (node.getAttribute('alt') !== 'variant') {
+        const subdivisionId = node.getAttribute('type');
+        subdivisionDisplayNames[subdivisionId] = node.textContent;
+      }
+    });
+    return subdivisionDisplayNames;
+  },
+
   extractCurrencyInfoById(localeId) {
     this.checkValidLocaleId(localeId);
     const finder = this.createFinder(

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -40,17 +40,17 @@ function Cldr(cldrPath) {
 }
 
 Cldr.prototype = {
-  fileNamesByTypeAndNormalizedLocaleId(type='main') {
+  fileNamesByTypeAndNormalizedLocaleId(type = 'main') {
     if (!this._fileNamesByTypeAndNormalizedLocaleId) {
       this._fileNamesByTypeAndNormalizedLocaleId = {};
     }
-    if (typeof this._fileNamesByTypeAndNormalizedLocaleId[type] === "undefined") {
+    if (
+      typeof this._fileNamesByTypeAndNormalizedLocaleId[type] === 'undefined'
+    ) {
       this._fileNamesByTypeAndNormalizedLocaleId[type] = {};
       let fileNames;
       try {
-        fileNames = fs.readdirSync(
-          Path.resolve(this.cldrPath, 'common', type)
-        );
+        fileNames = fs.readdirSync(Path.resolve(this.cldrPath, 'common', type));
       } catch (e) {
         if (e.code === 'ENOENT') {
           // Directory doesn't exist, just pretend it's empty.
@@ -72,7 +72,7 @@ Cldr.prototype = {
   get localeIds() {
     if (!this._localeIds) {
       this._localeIds = Object.keys(
-        this.fileNamesByTypeAndNormalizedLocaleId("main")
+        this.fileNamesByTypeAndNormalizedLocaleId('main')
       );
     }
     return this._localeIds;
@@ -316,8 +316,9 @@ Cldr.prototype = {
     ];
     Object.keys(neededLocaleById).forEach(localeId => {
       ['main', 'rbnf'].forEach(type => {
-        const fileName =
-          that.fileNamesByTypeAndNormalizedLocaleId(type)[localeId];
+        const fileName = that.fileNamesByTypeAndNormalizedLocaleId(type)[
+          localeId
+        ];
         if (fileName) {
           fileNames.push(fileName);
         }
@@ -509,10 +510,13 @@ Cldr.prototype = {
       this.getPrioritizedDocumentsForLocale(localeId, 'subdivisions')
     );
     const subdivisionDisplayNames = {};
-    finder('/ldml/localeDisplayNames/subdivisions/subdivision').forEach(node => {
-      const subdivisionId = node.getAttribute('type');
-      subdivisionDisplayNames[subdivisionId] = subdivisionDisplayNames[subdivisionId] || node.textContent;
-    });
+    finder('/ldml/localeDisplayNames/subdivisions/subdivision').forEach(
+      node => {
+        const subdivisionId = node.getAttribute('type');
+        subdivisionDisplayNames[subdivisionId] =
+          subdivisionDisplayNames[subdivisionId] || node.textContent;
+      }
+    );
     return subdivisionDisplayNames;
   },
 
@@ -1813,12 +1817,12 @@ Cldr.prototype = {
 
         for (const id of contains) {
           parentRegionIdByType[id] = type;
-        };
+        }
       }
     );
 
     for (const type of Object.keys(subdivisionContainmentGroups)) {
-      if (typeof parentRegionIdByType[type] !== "undefined") {
+      if (typeof parentRegionIdByType[type] !== 'undefined') {
         subdivisionContainmentGroups[type].parent = parentRegionIdByType[type];
       }
     }

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -490,6 +490,19 @@ Cldr.prototype = {
     return territoryDisplayNames;
   },
 
+  /**
+   * Subdivisions are usually subnational administrative entities.
+   * Codes follow the BCP47 standard, e.g. `usca` for California, USA.
+   * Note that these codes are similar but not identical to ISO 3166-2 codes.
+   * Unlike ISO 3166-2, CLDR never reuses a code.
+   *
+   * @param {string} [localeId='root'] Locale or subdivision names
+   * @returns {Object} A dictionary of subdivision codes and their names.
+   *
+   * @example
+   * // returns 'Zealand'
+   * cldr.extractSubdivisionDisplayNames('en').dk85
+   */
   extractSubdivisionDisplayNames(localeId) {
     this.checkValidLocaleId(localeId);
     const finder = this.createFinder(

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1788,6 +1788,46 @@ Cldr.prototype = {
     return territoryContainmentGroups;
   },
 
+  extractSubdivisionContainmentGroups() {
+    const finder = this.createFinder([
+      this.getDocument(
+        Path.resolve(
+          this.cldrPath,
+          'common',
+          'supplemental',
+          'subdivisions.xml'
+        )
+      )
+    ]);
+
+    const subdivisionContainmentGroups = {};
+    const parentRegionIdByType = {};
+
+    finder('/supplementalData/subdivisionContainment/subgroup').forEach(
+      groupNode => {
+        const type = groupNode.getAttribute('type');
+        const contains = groupNode.getAttribute('contains').split(' ');
+
+        subdivisionContainmentGroups[type] = {
+          type,
+          contains
+        };
+
+        contains.forEach(id => {
+          parentRegionIdByType[id] = type;
+        });
+      }
+    );
+
+    Object.keys(subdivisionContainmentGroups).forEach(type => {
+      if (typeof parentRegionIdByType[type] !== "undefined") {
+        subdivisionContainmentGroups[type].parent = parentRegionIdByType[type];
+      }
+    });
+
+    return subdivisionContainmentGroups;
+  },
+
   extractLanguageSupplementalData() {
     const finder = this.createFinder([
       this.getDocument(

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1811,17 +1811,17 @@ Cldr.prototype = {
           contains
         };
 
-        contains.forEach(id => {
+        for (const id of contains) {
           parentRegionIdByType[id] = type;
         });
       }
     );
 
-    Object.keys(subdivisionContainmentGroups).forEach(type => {
+    for (const type of Object.keys(subdivisionContainmentGroups)) {
       if (typeof parentRegionIdByType[type] !== "undefined") {
         subdivisionContainmentGroups[type].parent = parentRegionIdByType[type];
       }
-    });
+    }
 
     return subdivisionContainmentGroups;
   },

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -510,10 +510,8 @@ Cldr.prototype = {
     );
     const subdivisionDisplayNames = {};
     finder('/ldml/localeDisplayNames/subdivisions/subdivision').forEach(node => {
-      if (node.getAttribute('alt') !== 'variant') {
-        const subdivisionId = node.getAttribute('type');
-        subdivisionDisplayNames[subdivisionId] = subdivisionDisplayNames[subdivisionId] || node.textContent;
-      }
+      const subdivisionId = node.getAttribute('type');
+      subdivisionDisplayNames[subdivisionId] = subdivisionDisplayNames[subdivisionId] || node.textContent;
     });
     return subdivisionDisplayNames;
   },

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1813,7 +1813,7 @@ Cldr.prototype = {
 
         for (const id of contains) {
           parentRegionIdByType[id] = type;
-        });
+        };
       }
     );
 

--- a/test/cldr.js
+++ b/test/cldr.js
@@ -7,6 +7,7 @@ const localeLessExtractors = new Set([
   'extractTerritories',
   'extractTerritoryInfo',
   'extractTerritoryContainmentGroups',
+  'extractSubdivisionContainmentGroups',
   'extractLanguageSupplementalData',
   'extractLanguageSupplementalMetadata',
   'extractNumberingSystem',

--- a/test/extractSubdivisionContainmentGroups.js
+++ b/test/extractSubdivisionContainmentGroups.js
@@ -1,7 +1,7 @@
 const expect = require('unexpected');
 const cldr = require('../lib/cldr');
 
-describe('extractTerritoryContainmentGroups', () => {
+describe('extractSubdivisionContainmentGroups', () => {
   let subdivisionContainmentGroups;
   before(() => {
     subdivisionContainmentGroups = cldr.extractSubdivisionContainmentGroups();

--- a/test/extractSubdivisionContainmentGroups.js
+++ b/test/extractSubdivisionContainmentGroups.js
@@ -1,0 +1,20 @@
+const expect = require('unexpected');
+const cldr = require('../lib/cldr');
+
+describe('extractTerritoryContainmentGroups', () => {
+  let subdivisionContainmentGroups;
+  before(() => {
+    subdivisionContainmentGroups = cldr.extractSubdivisionContainmentGroups();
+  });
+
+  it('contains the chain UG > ugn > ug334', () => {
+    expect(subdivisionContainmentGroups, 'to have properties', [
+      'UG',
+      'ugn',
+    ]);
+    expect(subdivisionContainmentGroups.UG.contains, 'to contain', 'ugn');
+    expect(subdivisionContainmentGroups.ugn.contains, 'to contain', 'ug334');
+    expect(subdivisionContainmentGroups.ugn.parent, 'to equal', 'UG');
+  });
+
+});

--- a/test/extractSubdivisionContainmentGroups.js
+++ b/test/extractSubdivisionContainmentGroups.js
@@ -8,13 +8,9 @@ describe('extractSubdivisionContainmentGroups', () => {
   });
 
   it('contains the chain UG > ugn > ug334', () => {
-    expect(subdivisionContainmentGroups, 'to have properties', [
-      'UG',
-      'ugn',
-    ]);
+    expect(subdivisionContainmentGroups, 'to have properties', ['UG', 'ugn']);
     expect(subdivisionContainmentGroups.UG.contains, 'to contain', 'ugn');
     expect(subdivisionContainmentGroups.ugn.contains, 'to contain', 'ug334');
     expect(subdivisionContainmentGroups.ugn.parent, 'to equal', 'UG');
   });
-
 });

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -8,7 +8,7 @@ describe('extractTerritoryDisplayNames', () => {
     expect(territories, 'to have keys satisfying', /[A-Z0-9]{2,3}/);
   });
 
-  it('should contain localized named', () => {
+  it('should contain localized names', () => {
     const territoriesEn = cldr.extractTerritoryDisplayNames('en')
     const territoriesSv = cldr.extractTerritoryDisplayNames('sv')
     expect(territoriesEn.MK, 'to equal', 'North Macedonia');

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -9,25 +9,25 @@ describe('extractTerritoryDisplayNames', () => {
   });
 
   it('should contain localized named', () => {
-    const territories_en = cldr.extractTerritoryDisplayNames('en')
-    const territories_sv = cldr.extractTerritoryDisplayNames('sv')
-    expect(territories_en.MK, 'to equal', 'North Macedonia');
-    expect(territories_sv.MK, 'to equal', 'Nordmakedonien');
+    const territoriesEn = cldr.extractTerritoryDisplayNames('en')
+    const territoriesSv = cldr.extractTerritoryDisplayNames('sv')
+    expect(territoriesEn.MK, 'to equal', 'North Macedonia');
+    expect(territoriesSv.MK, 'to equal', 'Nordmakedonien');
   });
 
 });
 
 describe('extractSubdivisionDisplayNames', () => {
-  const subdivisions_en = cldr.extractSubdivisionDisplayNames('en')
-  const subdivisions_sv = cldr.extractSubdivisionDisplayNames('sv')
+  const subdivisionsEn = cldr.extractSubdivisionDisplayNames('en')
+  const subdivisionsSv = cldr.extractSubdivisionDisplayNames('sv')
 
   it('should export an object code - name dictionay', () => {
-    expect(subdivisions_en, 'to have keys satisfying', /[A-Za-z0-9]{1,4}/);
+    expect(subdivisionsEn, 'to have keys satisfying', /[A-Za-z0-9]{1,4}/);
   });
 
   it('should contain localized named', () => {
-    expect(subdivisions_en.dk85, 'to equal', 'Zealand');
-    expect(subdivisions_sv.dk85, 'to equal', 'Region Själland');
+    expect(subdivisionsEn.dk85, 'to equal', 'Zealand');
+    expect(subdivisionsSv.dk85, 'to equal', 'Region Själland');
   });
 
 });

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -21,7 +21,7 @@ describe('extractSubdivisionDisplayNames', () => {
   const subdivisionsEn = cldr.extractSubdivisionDisplayNames('en')
   const subdivisionsSv = cldr.extractSubdivisionDisplayNames('sv')
 
-  it('should export an object code - name dictionay', () => {
+  it('should export an object code - name dictionary', () => {
     expect(subdivisionsEn, 'to have keys satisfying', /[A-Za-z0-9]{1,4}/);
   });
 

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -22,7 +22,7 @@ describe('extractSubdivisionDisplayNames', () => {
   const subdivisions_sv = cldr.extractSubdivisionDisplayNames('sv')
 
   it('should export an object code - name dictionay', () => {
-    expect(subdivisions_en, 'to have keys satisfying', /[A-Za-z0-9]{2,6}/);
+    expect(subdivisions_en, 'to have keys satisfying', /[A-Za-z0-9]{1,4}/);
   });
 
   it('should contain localized named', () => {

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -3,7 +3,7 @@ const cldr = require('../lib/cldr');
 
 describe('extractTerritoryDisplayNames', () => {
 
-  it('should export an object code - name dictionay', () => {
+  it('should export an object code - name dictionary', () => {
     const territories = cldr.extractTerritoryDisplayNames('en')
     expect(territories, 'to have keys satisfying', /[A-Z0-9]{2,3}/);
   });

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -2,24 +2,22 @@ const expect = require('unexpected');
 const cldr = require('../lib/cldr');
 
 describe('extractTerritoryDisplayNames', () => {
-
   it('should export an object code - name dictionary', () => {
-    const territories = cldr.extractTerritoryDisplayNames('en')
+    const territories = cldr.extractTerritoryDisplayNames('en');
     expect(territories, 'to have keys satisfying', /[A-Z0-9]{2,3}/);
   });
 
   it('should contain localized names', () => {
-    const territoriesEn = cldr.extractTerritoryDisplayNames('en')
-    const territoriesSv = cldr.extractTerritoryDisplayNames('sv')
+    const territoriesEn = cldr.extractTerritoryDisplayNames('en');
+    const territoriesSv = cldr.extractTerritoryDisplayNames('sv');
     expect(territoriesEn.MK, 'to equal', 'North Macedonia');
     expect(territoriesSv.MK, 'to equal', 'Nordmakedonien');
   });
-
 });
 
 describe('extractSubdivisionDisplayNames', () => {
-  const subdivisionsEn = cldr.extractSubdivisionDisplayNames('en')
-  const subdivisionsSv = cldr.extractSubdivisionDisplayNames('sv')
+  const subdivisionsEn = cldr.extractSubdivisionDisplayNames('en');
+  const subdivisionsSv = cldr.extractSubdivisionDisplayNames('sv');
 
   it('should export an object code - name dictionary', () => {
     expect(subdivisionsEn, 'to have keys satisfying', /[A-Za-z0-9]{1,4}/);
@@ -29,5 +27,4 @@ describe('extractSubdivisionDisplayNames', () => {
     expect(subdivisionsEn.dk85, 'to equal', 'Zealand');
     expect(subdivisionsSv.dk85, 'to equal', 'Region Själland');
   });
-
 });

--- a/test/extractTerritoryDisplayNames.js
+++ b/test/extractTerritoryDisplayNames.js
@@ -1,0 +1,33 @@
+const expect = require('unexpected');
+const cldr = require('../lib/cldr');
+
+describe('extractTerritoryDisplayNames', () => {
+
+  it('should export an object code - name dictionay', () => {
+    const territories = cldr.extractTerritoryDisplayNames('en')
+    expect(territories, 'to have keys satisfying', /[A-Z0-9]{2,3}/);
+  });
+
+  it('should contain localized named', () => {
+    const territories_en = cldr.extractTerritoryDisplayNames('en')
+    const territories_sv = cldr.extractTerritoryDisplayNames('sv')
+    expect(territories_en.MK, 'to equal', 'North Macedonia');
+    expect(territories_sv.MK, 'to equal', 'Nordmakedonien');
+  });
+
+});
+
+describe('extractSubdivisionDisplayNames', () => {
+  const subdivisions_en = cldr.extractSubdivisionDisplayNames('en')
+  const subdivisions_sv = cldr.extractSubdivisionDisplayNames('sv')
+
+  it('should export an object code - name dictionay', () => {
+    expect(subdivisions_en, 'to have keys satisfying', /[A-Za-z0-9]{2,6}/);
+  });
+
+  it('should contain localized named', () => {
+    expect(subdivisions_en.dk85, 'to equal', 'Zealand');
+    expect(subdivisions_sv.dk85, 'to equal', 'Region Själland');
+  });
+
+});


### PR DESCRIPTION
@papandreou Here's an attempt at https://github.com/papandreou/node-cldr/issues/81

You may want to have a look at `fileNamesByTypeAndNormalizedLocaleId`, that is no longer a getter, but will fetch (and cache) only the data type that's going to be used.