### PR TITLE
Territory aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ cldr.extractLanguageDisplayNames('it').en;
 ('inglese');
 ```
 
+### cldr.extractSubdivisionAliases()
+
+Subdivision aliases contain deprecated or alternative subdivision codes. Note that the returned code may be either a territory code, (such as 'cn71' => 'TW'), or a subdivision code.
+
+```javascript
+cldr.extractSubdivisionAliases().czol;
+({ replacement: 'cz71', reason: 'deprecated' });
+```
+
 ### cldr.extractSubdivisionDisplayNames(localeId)
 
 Extract a subnational territory ID => display name hash for a locale.
@@ -242,6 +251,15 @@ cldr.extractTimeZoneFormats('da');
   region: 'Tidszone for {0}',
   fallback: '{1} ({0})',
   regions: { daylight: '{0} (+1)', standard: '{0} (+0)' } }
+```
+
+### cldr.extractTerritoryAliases()
+
+Territory aliases contain deprecated or alternative territory codes.
+
+```javascript
+cldr.extractTerritoryAliases().BU;
+({ replacement: 'MM', reason: 'deprecated' });
 ```
 
 ### cldr.extractTerritoryDisplayNames(localeId)

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -519,6 +519,47 @@ Cldr.prototype = {
     );
     return subdivisionDisplayNames;
   },
+  
+  /**
+   * Subdivision aliases contain deprecated or alternative subdivision
+   * codes. Note that the returned code may be either
+   * a territory code, (such as 'cn71' => 'TW'), or a subdivision code.
+   *
+   * @returns {Object} A dictionary with replacement code and reason
+   *
+   * @example
+   * // returns {replacement: 'cz71', reason: 'deprecated'}
+   * cldr.extractSubdivisionAliases().czol
+   *
+   * // returns {replacement: 'GU', reason: 'overlong'}
+   * cldr.extractSubdivisionAliases().usgu
+   */
+  extractSubdivisionAliases() {
+    const finder = this.createFinder([
+      this.getDocument(
+        Path.resolve(
+          this.cldrPath,
+          'common',
+          'supplemental',
+          'supplementalMetadata.xml'
+        )
+      )
+    ]);
+
+    const aliasData = {};
+
+    finder('/supplementalData/metadata/alias/subdivisionAlias').forEach(
+      subdivisionAliasNode => {
+        const type = subdivisionAliasNode.getAttribute('type');
+        aliasData[type] = {
+          replacement: subdivisionAliasNode.getAttribute('replacement'),
+          reason: subdivisionAliasNode.getAttribute('reason')
+        };
+      }
+    );
+
+    return aliasData;
+  },
 
   extractCurrencyInfoById(localeId) {
     this.checkValidLocaleId(localeId);

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -519,7 +519,7 @@ Cldr.prototype = {
     );
     return subdivisionDisplayNames;
   },
-  
+
   /**
    * Subdivision aliases contain deprecated or alternative subdivision
    * codes. Note that the returned code may be either
@@ -554,6 +554,43 @@ Cldr.prototype = {
         aliasData[type] = {
           replacement: subdivisionAliasNode.getAttribute('replacement'),
           reason: subdivisionAliasNode.getAttribute('reason')
+        };
+      }
+    );
+
+    return aliasData;
+  },
+
+  /**
+   * Territory aliases contain deprecated or alternative nation/territory
+   * codes. 
+   *
+   * @returns {Object} A dictionary with replacement code and reason
+   *
+   * @example
+   * // returns {replacement: 'MM', reason: 'deprecated'}
+   * cldr.extractTerritorpAliases().BU
+   */
+  extractTerritoryAliases() {
+    const finder = this.createFinder([
+      this.getDocument(
+        Path.resolve(
+          this.cldrPath,
+          'common',
+          'supplemental',
+          'supplementalMetadata.xml'
+        )
+      )
+    ]);
+
+    const aliasData = {};
+
+    finder('/supplementalData/metadata/alias/territoryAlias').forEach(
+      territoryAliasNode => {
+        const type = territoryAliasNode.getAttribute('type');
+        aliasData[type] = {
+          replacement: territoryAliasNode.getAttribute('replacement'),
+          reason: territoryAliasNode.getAttribute('reason')
         };
       }
     );

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -563,7 +563,7 @@ Cldr.prototype = {
 
   /**
    * Territory aliases contain deprecated or alternative nation/territory
-   * codes. 
+   * codes.
    *
    * @returns {Object} A dictionary with replacement code and reason
    *

--- a/test/cldr.js
+++ b/test/cldr.js
@@ -7,6 +7,7 @@ const localeLessExtractors = new Set([
   'extractTerritories',
   'extractTerritoryInfo',
   'extractTerritoryContainmentGroups',
+  'extractTerritoryAliases',
   'extractSubdivisionContainmentGroups',
   'extractSubdivisionAliases',
   'extractLanguageSupplementalData',

--- a/test/cldr.js
+++ b/test/cldr.js
@@ -8,6 +8,7 @@ const localeLessExtractors = new Set([
   'extractTerritoryInfo',
   'extractTerritoryContainmentGroups',
   'extractSubdivisionContainmentGroups',
+  'extractSubdivisionAliases',
   'extractLanguageSupplementalData',
   'extractLanguageSupplementalMetadata',
   'extractNumberingSystem',

--- a/test/extractTerritoryAliases.js
+++ b/test/extractTerritoryAliases.js
@@ -8,14 +8,13 @@ describe('extractTerritoryAliases', () => {
   });
 
   it('contains territory aliases', () => {
-    expect(territoryAliases, 'to have properties', [
-      'AN',
-      '062',
-      'BLZ'
-    ]);
+    expect(territoryAliases, 'to have properties', ['AN', '062', 'BLZ']);
   });
   it('aliases are arrays of replacement rules', () => {
-    expect(territoryAliases.BU, 'to have properties', ['replacement', 'reason']);
+    expect(territoryAliases.BU, 'to have properties', [
+      'replacement',
+      'reason'
+    ]);
     expect(territoryAliases.BU.replacement, 'to equal', 'MM');
     expect(territoryAliases.AN.replacement.split(' '), 'to have length', 3);
   });
@@ -28,17 +27,16 @@ describe('extractSubdivisionAliases', () => {
   });
 
   it('contains territory aliases', () => {
-    expect(subdivisionAliases, 'to have properties', [
-      'fi01',
-      'cn11',
-      'lug'
-    ]);
+    expect(subdivisionAliases, 'to have properties', ['fi01', 'cn11', 'lug']);
   });
   it('aliases are replacement rules', () => {
-    expect(subdivisionAliases.fi01, 'to have properties', ['replacement', 'reason']);
+    expect(subdivisionAliases.fi01, 'to have properties', [
+      'replacement',
+      'reason'
+    ]);
     expect(subdivisionAliases.fi01.replacement, 'to equal', 'AX');
     expect(subdivisionAliases.fi01.reason, 'to equal', 'overlong');
     expect(subdivisionAliases.cn11.reason, 'to equal', 'deprecated');
-    expect(subdivisionAliases.lug.replacement.split(" "), 'to have length', 3);
+    expect(subdivisionAliases.lug.replacement.split(' '), 'to have length', 3);
   });
 });

--- a/test/extractTerritoryAliases.js
+++ b/test/extractTerritoryAliases.js
@@ -1,0 +1,44 @@
+const expect = require('unexpected');
+const cldr = require('../lib/cldr');
+
+describe('extractTerritoryAliases', () => {
+  let territoryAliases;
+  before(() => {
+    territoryAliases = cldr.extractTerritoryAliases();
+  });
+
+  it('contains territory aliases', () => {
+    expect(territoryAliases, 'to have properties', [
+      'AN',
+      '062',
+      'BLZ'
+    ]);
+  });
+  it('aliases are arrays of replacement rules', () => {
+    expect(territoryAliases.BU, 'to have properties', ['replacement', 'reason']);
+    expect(territoryAliases.BU.replacement, 'to equal', 'MM');
+    expect(territoryAliases.AN.replacement.split(' '), 'to have length', 3);
+  });
+});
+
+describe('extractSubdivisionAliases', () => {
+  let subdivisionAliases;
+  before(() => {
+    subdivisionAliases = cldr.extractSubdivisionAliases();
+  });
+
+  it('contains territory aliases', () => {
+    expect(subdivisionAliases, 'to have properties', [
+      'fi01',
+      'cn11',
+      'lug'
+    ]);
+  });
+  it('aliases are replacement rules', () => {
+    expect(subdivisionAliases.fi01, 'to have properties', ['replacement', 'reason']);
+    expect(subdivisionAliases.fi01.replacement, 'to equal', 'AX');
+    expect(subdivisionAliases.fi01.reason, 'to equal', 'overlong');
+    expect(subdivisionAliases.cn11.reason, 'to equal', 'deprecated');
+    expect(subdivisionAliases.lug.replacement.split(" "), 'to have length', 3);
+  });
+});


### PR DESCRIPTION
This pull request adds the two methods `extractTerritoryAliases()` and `extractSubdivisionAliases()` to extract alternative territory codes. They don't parse the codes (splitting them by space) or anything, but just return the replacement string.