### PR TITLE
add method to extract supplemental week data

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,23 @@ or secondary for the language.
   [...] }
 ```
 
+### cldr.extractWeekData()
+
+Extract supplemental week data, including what day should be considered the first day of the week. The data is grouped by terrotories and/or locales.
+
+```javascript
+{ firstDay:
+  [
+    { day='mon', territories=[ '001', 'AD', [...] ] },
+    { day='fri', territories=[ 'MV'] },
+    { day='sat', territories=[ 'AE', 'AF', [...] ] },
+    { day='sun', territories=[ 'AG', 'AR', [...] ] },
+    { day='sun', variant=true, territories=[ 'GB' ] },
+  ],
+  [...] }
+```
+
+
 ## License
 
 node-cldr is licensed under a standard 3-clause BSD license -- see the

--- a/README.md
+++ b/README.md
@@ -915,7 +915,6 @@ Extract supplemental week data, including what day should be considered the firs
   [...] }
 ```
 
-
 ## License
 
 node-cldr is licensed under a standard 3-clause BSD license -- see the

--- a/README.md
+++ b/README.md
@@ -901,7 +901,7 @@ or secondary for the language.
 
 ### cldr.extractWeekData()
 
-Extract supplemental week data, including what day should be considered the first day of the week. The data is grouped by terrotories and/or locales.
+Extract supplemental week data, including what day should be considered the first day of the week. The data is grouped by territories and/or locales.
 
 ```javascript
 { firstDay:

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -2033,6 +2033,17 @@ Cldr.prototype = {
       });
     });
 
+    finder('/supplementalData/weekData/weekendEnd').forEach(weekendEnd => {
+      const territories = weekendEnd.getAttribute('territories').split(' ');
+      const day = weekendEnd.getAttribute('day');
+      const alt = weekendEnd.getAttribute('alt');
+      weekData.weekendEnd.push({
+        territories,
+        day,
+        variant: alt === 'variant'
+      });
+    });
+
     finder('/supplementalData/weekData/weekOfPreference').forEach(
       weekOfPreference => {
         const locales = weekOfPreference.getAttribute('locales').split(' ');

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -2025,22 +2025,18 @@ Cldr.prototype = {
     finder('/supplementalData/weekData/weekendStart').forEach(weekendStart => {
       const territories = weekendStart.getAttribute('territories').split(' ');
       const day = weekendStart.getAttribute('day');
-      const alt = weekendStart.getAttribute('alt');
       weekData.weekendStart.push({
         territories,
         day,
-        variant: alt === 'variant'
       });
     });
 
     finder('/supplementalData/weekData/weekendEnd').forEach(weekendEnd => {
       const territories = weekendEnd.getAttribute('territories').split(' ');
       const day = weekendEnd.getAttribute('day');
-      const alt = weekendEnd.getAttribute('alt');
       weekData.weekendEnd.push({
         territories,
         day,
-        variant: alt === 'variant'
       });
     });
 

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1983,7 +1983,6 @@ Cldr.prototype = {
    * https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Week_Data
    */
   extractWeekData() {
-
     const finder = this.createFinder([
       this.getDocument(
         Path.resolve(
@@ -2003,48 +2002,52 @@ Cldr.prototype = {
       weekOfPreference: []
     };
 
-    finder('/supplementalData/weekData/minDays').forEach(minDays => {
-      const territories = minDays.getAttribute('territories').split(' ');
-      const count = minDays.getAttribute('count');
+    finder('/supplementalData/weekData/minDays').forEach(minDaysNode => {
+      const territories = minDaysNode.getAttribute('territories').split(' ');
+      const count = minDaysNode.getAttribute('count');
       weekData.minDays.push({
         territories,
         count
       });
     });
 
-    finder('/supplementalData/weekData/firstDay').forEach(firstDay => {
-      const territories = firstDay.getAttribute('territories').split(' ');
-      const day = firstDay.getAttribute('day');
-      const alt = firstDay.getAttribute('alt');
+    finder('/supplementalData/weekData/firstDay').forEach(firstDayNode => {
+      const territories = firstDayNode.getAttribute('territories').split(' ');
+      const day = firstDayNode.getAttribute('day');
+      const alt = firstDayNode.getAttribute('alt');
       weekData.firstDay.push({
         territories,
         day,
         variant: alt === 'variant'
       });
     });
-  
-    finder('/supplementalData/weekData/weekendStart').forEach(weekendStart => {
-      const territories = weekendStart.getAttribute('territories').split(' ');
-      const day = weekendStart.getAttribute('day');
-      weekData.weekendStart.push({
-        territories,
-        day,
-      });
-    });
 
-    finder('/supplementalData/weekData/weekendEnd').forEach(weekendEnd => {
-      const territories = weekendEnd.getAttribute('territories').split(' ');
-      const day = weekendEnd.getAttribute('day');
+    finder('/supplementalData/weekData/weekendStart').forEach(
+      weekendStartNode => {
+        const territories = weekendStartNode
+          .getAttribute('territories')
+          .split(' ');
+        const day = weekendStartNode.getAttribute('day');
+        weekData.weekendStart.push({
+          territories,
+          day
+        });
+      }
+    );
+
+    finder('/supplementalData/weekData/weekendEnd').forEach(weekendEndNode => {
+      const territories = weekendEndNode.getAttribute('territories').split(' ');
+      const day = weekendEndNode.getAttribute('day');
       weekData.weekendEnd.push({
         territories,
-        day,
+        day
       });
     });
 
     finder('/supplementalData/weekData/weekOfPreference').forEach(
-      weekOfPreference => {
-        const locales = weekOfPreference.getAttribute('locales').split(' ');
-        const ordering = weekOfPreference.getAttribute('ordering');
+      weekOfPreferenceNode => {
+        const locales = weekOfPreferenceNode.getAttribute('locales').split(' ');
+        const ordering = weekOfPreferenceNode.getAttribute('ordering');
         weekData.weekOfPreference.push({
           locales,
           ordering

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1999,6 +1999,7 @@ Cldr.prototype = {
       minDays: [],
       firstDay: [],
       weekendStart: [],
+      weekendEnd: [],
       weekOfPreference: []
     };
 

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1707,14 +1707,14 @@ Cldr.prototype = {
     );
 
     const layout = {};
-    finder('/ldml/layout/*/*').forEach(leafNode => {
+    for (const leafNode of finder('/ldml/layout/*/*')) {
       const type = leafNode.nodeName;
 
       const parentType = leafNode.parentNode.nodeName;
       layout[parentType] = layout[parentType] || {};
       layout[parentType][type] =
         layout[parentType][type] || leafNode.textContent;
-    });
+    }
     return layout;
   },
 
@@ -1731,31 +1731,31 @@ Cldr.prototype = {
     ]);
 
     const territoryInfoByTerritoryId = {};
-    finder('/supplementalData/codeMappings/territoryCodes').forEach(
-      territoryCodeNode => {
-        const type = territoryCodeNode.getAttribute('type');
-        const numericCode = territoryCodeNode.getAttribute('numeric');
-        const alpha3Code = territoryCodeNode.getAttribute('alpha3');
+    for (const territoryCodeNode of finder(
+      '/supplementalData/codeMappings/territoryCodes'
+    )) {
+      const type = territoryCodeNode.getAttribute('type');
+      const numericCode = territoryCodeNode.getAttribute('numeric');
+      const alpha3Code = territoryCodeNode.getAttribute('alpha3');
 
-        const countryInfo = {
-          alpha2Code: type // ISO 3166-1 alpha-2
-        };
+      const countryInfo = {
+        alpha2Code: type // ISO 3166-1 alpha-2
+      };
 
-        if (alpha3Code) {
-          // ISO 3166-1 alpha-3
-          countryInfo.alpha3Code = alpha3Code;
-        }
-
-        if (numericCode) {
-          // UN M.49 / ISO-3166-1 numeric-3
-          // A numeric code may be reused by another country, e.g. Zaire and the DRC both have numeric code 180, but only the DRC currently exists
-          // Entries without a numeric code are few, which are usually exceptional reservations in ISO 3166-1 alpha-2. Example: IC, Canary Islands
-          countryInfo.numericCode = numericCode;
-        }
-
-        territoryInfoByTerritoryId[type] = countryInfo;
+      if (alpha3Code) {
+        // ISO 3166-1 alpha-3
+        countryInfo.alpha3Code = alpha3Code;
       }
-    );
+
+      if (numericCode) {
+        // UN M.49 / ISO-3166-1 numeric-3
+        // A numeric code may be reused by another country, e.g. Zaire and the DRC both have numeric code 180, but only the DRC currently exists
+        // Entries without a numeric code are few, which are usually exceptional reservations in ISO 3166-1 alpha-2. Example: IC, Canary Islands
+        countryInfo.numericCode = numericCode;
+      }
+
+      territoryInfoByTerritoryId[type] = countryInfo;
+    }
 
     return territoryInfoByTerritoryId;
   },
@@ -1773,23 +1773,23 @@ Cldr.prototype = {
     ]);
 
     const territoryInfoByTerritoryId = {};
-    finder('/supplementalData/territoryInfo/territory').forEach(
-      territoryNode => {
-        const territoryId = territoryNode.getAttribute('type');
-        territoryInfoByTerritoryId[territoryId] = {
-          id: territoryId,
-          gdp: parseInt(territoryNode.getAttribute('gdp'), 10),
-          literacyPercent: parseFloat(
-            territoryNode.getAttribute('literacyPercent')
-          ),
-          population: parseInt(territoryNode.getAttribute('population'), 10),
-          languages: []
-        };
-      }
-    );
-    finder(
+    for (const territoryNode of finder(
+      '/supplementalData/territoryInfo/territory'
+    )) {
+      const territoryId = territoryNode.getAttribute('type');
+      territoryInfoByTerritoryId[territoryId] = {
+        id: territoryId,
+        gdp: parseInt(territoryNode.getAttribute('gdp'), 10),
+        literacyPercent: parseFloat(
+          territoryNode.getAttribute('literacyPercent')
+        ),
+        population: parseInt(territoryNode.getAttribute('population'), 10),
+        languages: []
+      };
+    }
+    for (const languagePopulationNode of finder(
       '/supplementalData/territoryInfo/territory/languagePopulation'
-    ).forEach(languagePopulationNode => {
+    )) {
       const territoryId = languagePopulationNode.parentNode.getAttribute(
         'type'
       );
@@ -1812,7 +1812,7 @@ Cldr.prototype = {
         languageInfo.writingPercent = parseFloat(writingPercent);
       }
       territoryInfoByTerritoryId[territoryId].languages.push(languageInfo);
-    });
+    }
     return territoryInfoByTerritoryId;
   },
 
@@ -1833,28 +1833,28 @@ Cldr.prototype = {
     const isSeenByType = {};
     const parentRegionIdByType = {};
 
-    finder('/supplementalData/territoryContainment/group').forEach(
-      groupNode => {
-        const type = groupNode.getAttribute('type');
-        const contains = groupNode.getAttribute('contains').split(' ');
+    for (const groupNode of finder(
+      '/supplementalData/territoryContainment/group'
+    )) {
+      const type = groupNode.getAttribute('type');
+      const contains = groupNode.getAttribute('contains').split(' ');
 
-        if (!isSeenByType[type]) {
-          // Only look at the first occurence of a 'type', the first one overrides any items after it with the same type
-          isSeenByType[type] = true;
+      if (!isSeenByType[type]) {
+        // Only look at the first occurence of a 'type', the first one overrides any items after it with the same type
+        isSeenByType[type] = true;
 
-          territoryContainmentGroups[type] = {
-            type,
-            contains
-          };
+        territoryContainmentGroups[type] = {
+          type,
+          contains
+        };
 
-          contains.forEach(id => {
-            parentRegionIdByType[id] = type;
-          });
-        }
+        contains.forEach(id => {
+          parentRegionIdByType[id] = type;
+        });
       }
-    );
+    }
 
-    Object.keys(territoryContainmentGroups).forEach(type => {
+    for (const type of Object.keys(territoryContainmentGroups)) {
       // Territory containment groups that are not themselves somehow linked to the root world group '001', are not exposed because they're not part of the tree structure
       if (!(type in parentRegionIdByType)) {
         if (type !== '001') {
@@ -1863,7 +1863,7 @@ Cldr.prototype = {
       } else {
         territoryContainmentGroups[type].parent = parentRegionIdByType[type];
       }
-    });
+    }
 
     return territoryContainmentGroups;
   },
@@ -1883,21 +1883,21 @@ Cldr.prototype = {
     const subdivisionContainmentGroups = {};
     const parentRegionIdByType = {};
 
-    finder('/supplementalData/subdivisionContainment/subgroup').forEach(
-      groupNode => {
-        const type = groupNode.getAttribute('type');
-        const contains = groupNode.getAttribute('contains').split(' ');
+    for (const groupNode of finder(
+      '/supplementalData/subdivisionContainment/subgroup'
+    )) {
+      const type = groupNode.getAttribute('type');
+      const contains = groupNode.getAttribute('contains').split(' ');
 
-        subdivisionContainmentGroups[type] = {
-          type,
-          contains
-        };
+      subdivisionContainmentGroups[type] = {
+        type,
+        contains
+      };
 
-        for (const id of contains) {
-          parentRegionIdByType[id] = type;
-        }
+      for (const id of contains) {
+        parentRegionIdByType[id] = type;
       }
-    );
+    }
 
     for (const type of Object.keys(subdivisionContainmentGroups)) {
       if (typeof parentRegionIdByType[type] !== 'undefined') {
@@ -1922,7 +1922,9 @@ Cldr.prototype = {
 
     const languageData = {};
 
-    finder('/supplementalData/languageData/language').forEach(languageNode => {
+    for (const languageNode of finder(
+      '/supplementalData/languageData/language'
+    )) {
       const type = languageNode.getAttribute('type');
       const isSecondary = languageNode.getAttribute('alt') === 'secondary';
       let record;
@@ -1944,7 +1946,7 @@ Cldr.prototype = {
       if (territoriesAttr) {
         record.territories = territoriesAttr.split(' ');
       }
-    });
+    }
 
     return languageData;
   },
@@ -1963,15 +1965,15 @@ Cldr.prototype = {
 
     const languageData = {};
 
-    finder('/supplementalData/metadata/alias/languageAlias').forEach(
-      languageAliasNode => {
-        const type = languageAliasNode.getAttribute('type');
-        languageData[type] = {
-          replacement: languageAliasNode.getAttribute('replacement'),
-          reason: languageAliasNode.getAttribute('reason')
-        };
-      }
-    );
+    for (const languageAliasNode of finder(
+      '/supplementalData/metadata/alias/languageAlias'
+    )) {
+      const type = languageAliasNode.getAttribute('type');
+      languageData[type] = {
+        replacement: languageAliasNode.getAttribute('replacement'),
+        reason: languageAliasNode.getAttribute('reason')
+      };
+    }
 
     return languageData;
   },
@@ -2002,16 +2004,16 @@ Cldr.prototype = {
       weekOfPreference: []
     };
 
-    finder('/supplementalData/weekData/minDays').forEach(minDaysNode => {
+    for (const minDaysNode of finder('/supplementalData/weekData/minDays')) {
       const territories = minDaysNode.getAttribute('territories').split(' ');
       const count = minDaysNode.getAttribute('count');
       weekData.minDays.push({
         territories,
         count
       });
-    });
+    }
 
-    finder('/supplementalData/weekData/firstDay').forEach(firstDayNode => {
+    for (const firstDayNode of finder('/supplementalData/weekData/firstDay')) {
       const territories = firstDayNode.getAttribute('territories').split(' ');
       const day = firstDayNode.getAttribute('day');
       const alt = firstDayNode.getAttribute('alt');
@@ -2020,40 +2022,42 @@ Cldr.prototype = {
         day,
         variant: alt === 'variant'
       });
-    });
+    }
 
-    finder('/supplementalData/weekData/weekendStart').forEach(
-      weekendStartNode => {
-        const territories = weekendStartNode
-          .getAttribute('territories')
-          .split(' ');
-        const day = weekendStartNode.getAttribute('day');
-        weekData.weekendStart.push({
-          territories,
-          day
-        });
-      }
-    );
+    for (const weekendStartNode of finder(
+      '/supplementalData/weekData/weekendStart'
+    )) {
+      const territories = weekendStartNode
+        .getAttribute('territories')
+        .split(' ');
+      const day = weekendStartNode.getAttribute('day');
+      weekData.weekendStart.push({
+        territories,
+        day
+      });
+    }
 
-    finder('/supplementalData/weekData/weekendEnd').forEach(weekendEndNode => {
+    for (const weekendEndNode of finder(
+      '/supplementalData/weekData/weekendEnd'
+    )) {
       const territories = weekendEndNode.getAttribute('territories').split(' ');
       const day = weekendEndNode.getAttribute('day');
       weekData.weekendEnd.push({
         territories,
         day
       });
-    });
+    }
 
-    finder('/supplementalData/weekData/weekOfPreference').forEach(
-      weekOfPreferenceNode => {
-        const locales = weekOfPreferenceNode.getAttribute('locales').split(' ');
-        const ordering = weekOfPreferenceNode.getAttribute('ordering');
-        weekData.weekOfPreference.push({
-          locales,
-          ordering
-        });
-      }
-    );
+    for (const weekOfPreferenceNode of finder(
+      '/supplementalData/weekData/weekOfPreference'
+    )) {
+      const locales = weekOfPreferenceNode.getAttribute('locales').split(' ');
+      const ordering = weekOfPreferenceNode.getAttribute('ordering');
+      weekData.weekOfPreference.push({
+        locales,
+        ordering
+      });
+    }
 
     return weekData;
   }

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1974,6 +1974,77 @@ Cldr.prototype = {
     );
 
     return languageData;
+  },
+
+  /**
+   * Weekdata contains various week related info, grouped by territory or locale
+   * Defaults are indicated by territory="001" or locale="und"
+   *
+   * https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Week_Data
+   */
+  extractWeekData() {
+
+    const finder = this.createFinder([
+      this.getDocument(
+        Path.resolve(
+          this.cldrPath,
+          'common',
+          'supplemental',
+          'supplementalData.xml'
+        )
+      )
+    ]);
+
+    const weekData = {
+      minDays: [],
+      firstDay: [],
+      weekendStart: [],
+      weekOfPreference: []
+    };
+
+    finder('/supplementalData/weekData/minDays').forEach(minDays => {
+      const territories = minDays.getAttribute('territories').split(' ');
+      const count = minDays.getAttribute('count');
+      weekData.minDays.push({
+        territories,
+        count
+      });
+    });
+
+    finder('/supplementalData/weekData/firstDay').forEach(firstDay => {
+      const territories = firstDay.getAttribute('territories').split(' ');
+      const day = firstDay.getAttribute('day');
+      const alt = firstDay.getAttribute('alt');
+      weekData.firstDay.push({
+        territories,
+        day,
+        variant: alt === 'variant'
+      });
+    });
+  
+    finder('/supplementalData/weekData/weekendStart').forEach(weekendStart => {
+      const territories = weekendStart.getAttribute('territories').split(' ');
+      const day = weekendStart.getAttribute('day');
+      const alt = weekendStart.getAttribute('alt');
+      weekData.weekendStart.push({
+        territories,
+        day,
+        variant: alt === 'variant'
+      });
+    });
+
+    finder('/supplementalData/weekData/weekOfPreference').forEach(
+      weekOfPreference => {
+        const locales = weekOfPreference.getAttribute('locales').split(' ');
+        const ordering = weekOfPreference.getAttribute('ordering');
+        weekData.weekOfPreference.push({
+          locales,
+          ordering
+        });
+      }
+    );
+
+    return weekData;
   }
 };
 

--- a/test/cldr.js
+++ b/test/cldr.js
@@ -13,7 +13,8 @@ const localeLessExtractors = new Set([
   'extractLanguageSupplementalData',
   'extractLanguageSupplementalMetadata',
   'extractNumberingSystem',
-  'extractDigitsByNumberSystemId'
+  'extractDigitsByNumberSystemId',
+  'extractWeekData'
 ]);
 
 describe('cldr', function() {

--- a/test/extractWeekData.js
+++ b/test/extractWeekData.js
@@ -2,7 +2,6 @@ const expect = require('unexpected');
 const cldr = require('../lib/cldr');
 
 describe('cldr.extractWeekData()', () => {
-
   it('should extract arrays of data', () => {
     expect(cldr.extractWeekData(), 'to have keys', [
       'minDays',
@@ -49,5 +48,4 @@ describe('cldr.extractWeekData()', () => {
       'AF'
     );
   });
-
 });

--- a/test/extractWeekData.js
+++ b/test/extractWeekData.js
@@ -1,0 +1,49 @@
+const expect = require('unexpected');
+const cldr = require('../lib/cldr');
+
+describe('cldr.extractWeekData()', () => {
+  it('should extract arrays of data', () => {
+    expect(cldr.extractWeekData(), 'to have keys', [
+      'minDays',
+      'firstDay',
+      'weekendStart',
+      'weekendEnd',
+      'weekOfPreference'
+    ]);
+  });
+  it('should include exactly one default', () => {
+    expect(
+      cldr.extractWeekData().minDays.filter(x => x.territories.includes('001')),
+      'to have length',
+      1
+    );
+    expect(
+      cldr
+        .extractWeekData()
+        .weekendStart.filter(x => x.territories.includes('001')),
+      'to have length',
+      1
+    );
+    expect(
+      cldr
+        .extractWeekData()
+        .weekOfPreference.filter(x => x.locales.includes('und')),
+      'to have length',
+      1
+    );
+  });
+  it('should include custom values for a territory', () => {
+    expect(
+      cldr.extractWeekData().firstDay.filter(x => x.day === 'fri')[0]
+        .territories,
+      'to contain',
+      'MV'
+    );
+    expect(
+      cldr.extractWeekData().firstDay.filter(x => x.day === 'sat')[0]
+        .territories,
+      'to contain',
+      'AF'
+    );
+  });
+});

--- a/test/extractWeekData.js
+++ b/test/extractWeekData.js
@@ -2,6 +2,7 @@ const expect = require('unexpected');
 const cldr = require('../lib/cldr');
 
 describe('cldr.extractWeekData()', () => {
+
   it('should extract arrays of data', () => {
     expect(cldr.extractWeekData(), 'to have keys', [
       'minDays',
@@ -11,6 +12,7 @@ describe('cldr.extractWeekData()', () => {
       'weekOfPreference'
     ]);
   });
+
   it('should include exactly one default', () => {
     expect(
       cldr.extractWeekData().minDays.filter(x => x.territories.includes('001')),
@@ -32,6 +34,7 @@ describe('cldr.extractWeekData()', () => {
       1
     );
   });
+
   it('should include custom values for a territory', () => {
     expect(
       cldr.extractWeekData().firstDay.filter(x => x.day === 'fri')[0]
@@ -46,4 +49,5 @@ describe('cldr.extractWeekData()', () => {
       'AF'
     );
   });
+
 });


### PR DESCRIPTION
suggestion to add method for extracting [supplemental week data](https://www.unicode.org/reports/tr35/tr35-55/tr35-dates.html#Week_Data). The data structure is a bit different from most other data extracted by this lib, so just let me know if it feels like this is out of scope.

```
{ firstDay:
  [
    { day='mon', territories=[ '001', 'AD', [...] ] },
    { day='fri', territories=[ 'MV'] },
    { day='sat', territories=[ 'AE', 'AF', [...] ] },
    { day='sun', territories=[ 'AG', 'AR', [...] ] },
    { day='sun', variant=true, territories=[ 'GB' ] },
  ],
  [...] }
```