### PR TITLE
Allow alternative territory names

### DIFF
--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -482,7 +482,12 @@ Cldr.prototype = {
     const territoryDisplayNames = {};
     finder('/ldml/localeDisplayNames/territories/territory').forEach(
       territoryNode => {
-        const territoryId = territoryNode.getAttribute('type');
+        let territoryId = territoryNode.getAttribute('type');
+        const alternative = territoryNode.getAttribute('alt');
+        if (alternative) {
+          // Use the same format for alternative names as cldr-json (e.g. BA-alt-short)
+          territoryId = `${territoryId}-alt-${alternative}`;
+        }
         territoryDisplayNames[territoryId] =
           territoryDisplayNames[territoryId] || territoryNode.textContent;
       }


### PR DESCRIPTION
This pull request adds support for alternative names of territories which are currently completely missing. As they are included in `cldr-json`, I thought it migh be good to use the same format [as they also use](https://github.com/unicode-cldr/cldr-localenames-full/blob/61bfd825740ffb9f5ff31ab86da6b454ba4c1cc9/main/en/territories.json#L62), e.g. `BA-alt-short`