### PR TITLE
rbnf: Support non-latn numbering systems

### DIFF
--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1598,8 +1598,29 @@ Cldr.prototype = {
       ? [].concat(types)
       : Object.keys(cldrRbnfRuleSetByType);
 
+    const defaultNumberingSystem = this.extractDefaultNumberSystemId(localeId);
+    const numberingSystem = this.extractNumberingSystem(defaultNumberingSystem);
+    if (numberingSystem.type === 'algorithmic') {
+      typesToAdd.push(numberingSystem.rules);
+    }
+    const zeroCharCode = '0'.charCodeAt(0);
     const rbnfFunctionByType = {
-      renderNumber: String // Provide a (bad) default number rendering implementation to avoid #13
+      // Provide a (bad) default number rendering implementation to avoid #13
+      renderNumber(number) {
+        if (numberingSystem.type === 'numeric') {
+          return String(number)
+            .split(/(?:)/)
+            .map(ch => {
+              return (
+                numberingSystem.digits[ch.charCodeAt(0) - zeroCharCode] || ch
+              );
+            })
+            .join('');
+        } else {
+          // numberingSystem.type === 'algorithmic'
+          return this[numberingSystem.rules](number);
+        }
+      }
     };
     while (typesToAdd.length > 0) {
       const type = typesToAdd.shift();

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nyc": "^15.0.0",
     "offline-github-changelog": "^1.6.1",
     "prettier": "~1.19.1",
+    "sinon": "^8.0.4",
     "unexpected": "^11.7.0",
     "unexpected-function-equality": "^2.0.0"
   },

--- a/test/extractRbnfFunctionByType.js
+++ b/test/extractRbnfFunctionByType.js
@@ -2,6 +2,7 @@ const unexpected = require('unexpected');
 const esprima = require('esprima');
 const escodegen = require('escodegen');
 const cldr = require('../lib/cldr');
+const sinon = require('sinon');
 
 function beautifyJavaScript(functionOrAst) {
   let ast;
@@ -254,5 +255,26 @@ describe('extractRbnfFunctionByType', () => {
       'to equal',
       'two point zero zero nine five'
     );
+  });
+
+  describe('with locales that have a non-latin default numbering system', function() {
+    it('should support a numbering system with different digits', function() {
+      const renderers = cldr.extractRbnfFunctionByType('ar');
+      expect(renderers.renderDigitsOrdinal(3), 'to equal', '٣.');
+    });
+
+    it('should support an algorithmic numbering system', function() {
+      // None of the locales in CLDR actually use one, so fake it:
+      sinon
+        .stub(cldr, 'extractDefaultNumberSystemId')
+        .withArgs('ar')
+        .returns('roman');
+      try {
+        const renderers = cldr.extractRbnfFunctionByType('ar');
+        expect(renderers.renderDigitsOrdinal(3), 'to equal', 'III.');
+      } finally {
+        cldr.extractDefaultNumberSystemId.restore();
+      }
+    });
   });
 });


### PR DESCRIPTION
Fixes #108

Seems like we just didn't pick up the `<defaultNumberingSystem>`.