### PR TITLE
Add support for new CLDR plural operands `e` and `c`.

### DIFF
--- a/lib/CldrPluralRule.js
+++ b/lib/CldrPluralRule.js
@@ -105,12 +105,16 @@ function nodeToJavaScriptAst(node) {
         type: 'Literal',
         value: node.value,
       };
+    // Based on the list of characters which are valid operands in the plural syntax.
+    // See: http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax
     case 'n':
     case 'i':
-    case 'v':
-    case 'w':
     case 'f':
     case 't':
+    case 'v':
+    case 'w':
+    case 'c':
+    case 'e':
       return {
         type: 'Identifier',
         name: node.type,
@@ -222,7 +226,9 @@ CldrPluralRule.prototype = {
 
   updateIsUsedByTerm(isUsedByTerm) {
     this.eachNode((node) => {
-      if (['i', 'v', 'w', 'f', 't', 'n'].indexOf(node.type) !== -1) {
+      // Based on the list of characters which are valid operands in the plural syntax.
+      // See: http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax
+      if (['i', 'v', 'w', 'f', 't', 'n', 'c', 'e'].indexOf(node.type) !== -1) {
         isUsedByTerm[node.type] = true;
       }
     });

--- a/lib/CldrPluralRuleSet.js
+++ b/lib/CldrPluralRuleSet.js
@@ -59,7 +59,9 @@ CldrPluralRuleSet.prototype = {
     });
     const varAsts = [];
 
-    ['i', 'v', 'w', 'f', 't'].forEach((term) => {
+    // Based on the list of characters which are valid operands in the plural syntax.
+    // See: http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax
+    ['i', 'v', 'w', 'f', 't', 'c', 'e'].forEach((term) => {
       if (isUsedByTerm[term]) {
         varAsts.push({
           type: 'VariableDeclarator',

--- a/lib/cldrPluralRule.pegjs
+++ b/lib/cldrPluralRule.pegjs
@@ -27,6 +27,8 @@ TERM          = INT
               / "w"i                                               { return {type: 'w'}; }
               / "f"i                                               { return {type: 'f'}; }
               / "t"i                                               { return {type: 't'}; }
+              / "e"i                                               { return {type: 'e'}; }
+              / "c"i                                               { return {type: "c"}; }
 
 RANGELIST     = range:RANGE " "* "," " "* rangelist:RANGELIST      { rangelist.ranges.unshift(range); return rangelist; }
               / range:RANGE                                        { return {type: 'rangelist', ranges: [range]}; }

--- a/lib/cldrPluralRuleTermFunctionByName.js
+++ b/lib/cldrPluralRuleTermFunctionByName.js
@@ -17,3 +17,14 @@ exports.f = function f(n) {
 exports.t = function t(n) {
   return parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
 };
+
+// http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax. See `e` operand.
+// The implementation can only determine the exponent properly if `n` is passed as string.
+exports.e = function e(n) {
+  // eslint-disable-next-line no-return-assign
+  return (n = n.toString().match(/^\d+e(\d+)$/), n === null ? 0 : parseInt(n[1], 10));
+}
+
+// http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax. The `c` operand is
+// currently equal to the `e` operand. We use the same implementation.
+exports.c = exports.e;

--- a/test/CldrPluralRuleSet.js
+++ b/test/CldrPluralRuleSet.js
@@ -135,6 +135,26 @@ describe('CldrPluralRuleSet', () => {
     );
   });
 
+  it('should encode the French plural rule function from CLDR 39 correctly', () => {
+    expect({
+      one: 'i = 0,1 @integer 0, 1 @decimal 0.0~1.5',
+      many: 'e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …',
+      other: ' @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …',
+    }, 'to encode to',
+    // prettier-ignore
+    function (n) {
+        /* eslint-disable */
+        const i = Math.floor(Math.abs(n)),
+          v = n.toString().replace(/^[^.]*\.?/, '').length,
+          e = (n = n.toString().match(/^\d+e(\d+)$/), n === null ? 0 : parseInt(n[1], 10));
+        if (typeof n === 'string') n = parseInt(n, 10);
+        if (i === 0 || i === 1) return 'one';
+        if (e === 0 && (!(i === 0) && (i % 1000000 === 0 && v === 0)) || !(e >= 0 && e <= 5)) return 'many';
+        return 'other';
+        /* eslint-enable */
+    });
+  });
+
   it('should encode the Slovak plural rule function from CLDR 29 correctly', () => {
     expect(
       {

--- a/test/cldrPluralRuleTermFunctionByName.js
+++ b/test/cldrPluralRuleTermFunctionByName.js
@@ -50,6 +50,22 @@ const expectedOutputByTermAndInput = {
     1.03: 3,
     '1.230': 23,
   },
+  e: {
+    1: 0,
+    '1.0': 0,
+    '1.0.0': 0,
+    10e10: 0,
+    '10e10': 10,
+    '10': 0,
+  },
+  c: {
+    1: 0,
+    '1.0': 0,
+    '1.0.0': 0,
+    10e10: 0,
+    '10e10': 10,
+    '10': 0,
+  }
 };
 
 describe('cldrPluralRuleTermFunctionByName', () => {


### PR DESCRIPTION
The `cldr` package currently comes with CLDR 39 but the actual
plural expressions cannot be properly extracted/generated.

For example, the french plural uses the new `e` operand, but
the parser does not know about such. This commit adds support
for the new operands.

@papandreou When you get a chance, I'd appreciate your review on this. As mentioned,
currently extracting the plurals from CLDR 39 is not working in all cases. e.g.

```
(node:19684) UnhandledPromiseRejectionWarning: SyntaxError: Expected " not ", "f", "i", "n", "t", "v", "w", [0-9], or [\-+] but "e" found.
    at peg$buildStructuredError (eval at compile (C:\users\paul\_bazel_paul\gsqtgr5s\execroot\angular\node_modules\pegjs\lib\compiler\index.js:67:29), <anonymous>:343:14)
    at Object.peg$parse [as parse] (eval at compile (C:\users\paul\_bazel_paul\gsqtgr5s\execroot\angular\node_modules\pegjs\lib\compiler\index.js:67:29), <anonymous>:1164:13)
    at new CldrPluralRule (C:\users\paul\_bazel_paul\gsqtgr5s\execroot\angular\node_modules\cldr\lib\CldrPluralRule.js:209:30)
    at CldrPluralRuleSet.addRule (C:\users\paul\_bazel_paul\gsqtgr5s\execroot\angular\node_modules\cldr\lib\CldrPluralRuleSet.js:20:24)
```