### PR TITLE
Do not accidentally override `n` operand when generating `e` and `c` operands

### DIFF
--- a/lib/CldrPluralRuleSet.js
+++ b/lib/CldrPluralRuleSet.js
@@ -58,28 +58,15 @@ CldrPluralRuleSet.prototype = {
       },
     });
 
-    const helperVariables = [];
-    const operandConstants = [];
-
-    // For `c` and `e` operands, a temporary variable is needed to store the
-    // RegExp match results. See `cldrPluralRuleTermFunctionByName.js`.
-    ['c', 'e'].forEach((term) => {
-      if (isUsedByTerm[term]) {
-        helperVariables.push({
-          type: 'VariableDeclarator',
-          id: {
-            type: 'Identifier',
-            name: '_tmpPlural',
-          },
-        });
-      }
-    });
+    const varAsts = [];
 
     // Based on the list of characters which are valid operands in the plural syntax.
     // See: http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax
-    ['i', 'v', 'w', 'f', 't', 'c', 'e'].forEach((term) => {
-      if (isUsedByTerm[term]) {
-        operandConstants.push({
+    ['n', 'i', 'v', 'w', 'f', 't', 'c', 'e'].forEach((term) => {
+      // the `n` operand variable is always generated as it's used later to ensure
+      // that a valid number has been specified to the plural function.
+      if (term === 'n' || isUsedByTerm[term]) {
+        varAsts.push({
           type: 'VariableDeclarator',
           id: {
             type: 'Identifier',
@@ -91,75 +78,47 @@ CldrPluralRuleSet.prototype = {
       }
     });
 
-    if (Object.keys(isUsedByTerm).length !== 0) {
-      statementAsts.unshift({
-        // if (typeof n === 'string') n = parseInt(n, 10);
-        type: 'IfStatement',
-        test: {
-          type: 'BinaryExpression',
-          operator: '===',
-          left: {
-            type: 'UnaryExpression',
-            operator: 'typeof',
-            prefix: true,
-            argument: {
-              type: 'Identifier',
-              name: 'n',
-            },
-          },
-          right: {
-            type: 'Literal',
-            value: 'string',
-          },
+    statementAsts.unshift({
+      // if (isNaN(n)) throw Error('n is not a number');
+      type: 'IfStatement',
+      test: {
+        type: 'CallExpression',
+        callee: {
+          type: 'Identifier',
+          name: 'isNaN',
         },
-        consequent: {
-          type: 'ExpressionStatement',
-          expression: {
-            type: 'AssignmentExpression',
-            operator: '=',
-            left: {
-              type: 'Identifier',
-              name: 'n',
-            },
-            right: {
-              type: 'CallExpression',
-              callee: {
-                type: 'Identifier',
-                name: 'parseInt',
-              },
-              arguments: [
-                {
-                  type: 'Identifier',
-                  name: 'n',
-                },
-                {
-                  type: 'Literal',
-                  value: 10,
-                },
-              ],
-            },
+        arguments: [
+          {
+            type: 'Identifier',
+            name: 'n',
           },
+        ],
+      },
+      consequent: {
+        type: 'ThrowStatement',
+        argument: {
+          type: 'CallExpression',
+          callee: {
+            type: 'Identifier',
+            name: 'Error',
+          },
+          arguments: [
+            {
+              type: 'Literal',
+              value: 'n is not a number',
+            },
+          ],
         },
-      });
-    }
+      },
+    });
 
-    if (operandConstants.length > 0) {
+    if (varAsts.length > 0) {
       statementAsts.unshift({
         type: 'VariableDeclaration',
         kind: 'const',
-        declarations: operandConstants,
+        declarations: varAsts,
       });
     }
-
-    if (helperVariables.length > 0) {
-      statementAsts.unshift({
-        type: 'VariableDeclaration',
-        // Helper variables are supposed to be mutable.
-        kind: 'let',
-        declarations: helperVariables,
-      });
-    }
-
     return statementAsts;
   },
 };

--- a/lib/CldrPluralRuleSet.js
+++ b/lib/CldrPluralRuleSet.js
@@ -57,13 +57,29 @@ CldrPluralRuleSet.prototype = {
         value: 'other',
       },
     });
-    const varAsts = [];
+
+    const helperVariables = [];
+    const operandConstants = [];
+
+    // For `c` and `e` operands, a temporary variable is needed to store the
+    // RegExp match results. See `cldrPluralRuleTermFunctionByName.js`.
+    ['c', 'e'].forEach((term) => {
+      if (isUsedByTerm[term]) {
+        helperVariables.push({
+          type: 'VariableDeclarator',
+          id: {
+            type: 'Identifier',
+            name: '_tmpPlural',
+          },
+        });
+      }
+    });
 
     // Based on the list of characters which are valid operands in the plural syntax.
     // See: http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax
     ['i', 'v', 'w', 'f', 't', 'c', 'e'].forEach((term) => {
       if (isUsedByTerm[term]) {
-        varAsts.push({
+        operandConstants.push({
           type: 'VariableDeclarator',
           id: {
             type: 'Identifier',
@@ -127,13 +143,23 @@ CldrPluralRuleSet.prototype = {
       });
     }
 
-    if (varAsts.length > 0) {
+    if (operandConstants.length > 0) {
       statementAsts.unshift({
         type: 'VariableDeclaration',
         kind: 'const',
-        declarations: varAsts,
+        declarations: operandConstants,
       });
     }
+
+    if (helperVariables.length > 0) {
+      statementAsts.unshift({
+        type: 'VariableDeclaration',
+        // Helper variables are supposed to be mutable.
+        kind: 'let',
+        declarations: helperVariables,
+      });
+    }
+
     return statementAsts;
   },
 };

--- a/lib/CldrRbnfRuleSet.js
+++ b/lib/CldrRbnfRuleSet.js
@@ -77,7 +77,8 @@ CldrRbnfRuleSet.prototype = {
                 params: [
                   {
                     type: 'Identifier',
-                    name: 'n',
+                    // The plural functions expect the parameter to be named `val`.
+                    name: 'val',
                   },
                 ],
                 body: {
@@ -468,6 +469,7 @@ CldrRbnfRuleSet.prototype = {
     }
 
     const statementAsts = [];
+
     if (this.ruleByValue['x.0'] || this.ruleByValue['x.x']) {
       // var isFractional = n !== Math.floor(n);
       statementAsts.push({

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -1537,7 +1537,7 @@ Cldr.prototype = {
     this.checkValidLocaleId(localeId);
     // eslint-disable-next-line no-new-func
     return new Function(
-      'n',
+      'val',
       escodegen.generate({
         type: 'Program',
         body: this._extractPluralRuleAst(localeId, cardinalOrOrdinal),

--- a/lib/cldrPluralRuleTermFunctionByName.js
+++ b/lib/cldrPluralRuleTermFunctionByName.js
@@ -18,12 +18,19 @@ exports.t = function t(n) {
   return parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
 };
 
+// Note: `_tmpPlural` is a temporary variable created if the `e` and `c` operands are used.
+// See `CldrPluralRuleSet.js`. We need to add this helper variable here to ensure that
+// Mocha does not complain about a global variable being introduced. This would happen
+// if the `e` and `c` function is executed with the `_tmpPlural` assignment to `global`.
+let _tmpPlural;
+
 // http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax. See `e` operand.
 // The implementation can only determine the exponent properly if `n` is passed as string.
 exports.e = function e(n) {
   // eslint-disable-next-line no-return-assign
   return (
-    (n = n.toString().match(/^\d+e(\d+)$/)), n === null ? 0 : parseInt(n[1], 10)
+    (_tmpPlural = n.toString().match(/^\d+e(\d+)$/)),
+    _tmpPlural === null ? 0 : parseInt(_tmpPlural[1], 10)
   );
 };
 

--- a/lib/cldrPluralRuleTermFunctionByName.js
+++ b/lib/cldrPluralRuleTermFunctionByName.js
@@ -1,37 +1,31 @@
-exports.i = function i(n) {
-  return Math.floor(Math.abs(n));
+exports.n = function n(val) {
+  return Number(val);
 };
 
-exports.v = function v(n) {
-  return n.toString().replace(/^[^.]*\.?/, '').length;
+exports.i = function i(val) {
+  return Math.floor(Math.abs(val));
 };
 
-exports.w = function w(n) {
-  return n.toString().replace(/^[^.]*\.?|0+$/g, '').length;
+exports.v = function v(val) {
+  return val.toString().replace(/^[^.]*\.?/, '').length;
 };
 
-exports.f = function f(n) {
-  return parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
+exports.w = function w(val) {
+  return val.toString().replace(/^[^.]*\.?|0+$/g, '').length;
 };
 
-exports.t = function t(n) {
-  return parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
+exports.f = function f(val) {
+  return parseInt(val.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
 };
 
-// Note: `_tmpPlural` is a temporary variable created if the `e` and `c` operands are used.
-// See `CldrPluralRuleSet.js`. We need to add this helper variable here to ensure that
-// Mocha does not complain about a global variable being introduced. This would happen
-// if the `e` and `c` function is executed with the `_tmpPlural` assignment to `global`.
-let _tmpPlural;
+exports.t = function t(val) {
+  return parseInt(val.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
+};
 
 // http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax. See `e` operand.
 // The implementation can only determine the exponent properly if `n` is passed as string.
-exports.e = function e(n) {
-  // eslint-disable-next-line no-return-assign
-  return (
-    (_tmpPlural = n.toString().match(/^\d+e(\d+)$/)),
-    _tmpPlural === null ? 0 : parseInt(_tmpPlural[1], 10)
-  );
+exports.e = function e(val) {
+  return parseInt(val.toString().replace(/^[^e]*(e([-+]?\d+))?/, '$2')) || 0;
 };
 
 // http://unicode.org/reports/tr35/tr35-numbers.html#Plural_rules_syntax. The `c` operand is

--- a/test/CldrPluralRuleSet.js
+++ b/test/CldrPluralRuleSet.js
@@ -147,9 +147,10 @@ describe('CldrPluralRuleSet', () => {
       // prettier-ignore
       function (n) {
         /* eslint-disable */
+        let _tmpPlural;
         const i = Math.floor(Math.abs(n)),
           v = n.toString().replace(/^[^.]*\.?/, '').length,
-          e = (n = n.toString().match(/^\d+e(\d+)$/), n === null ? 0 : parseInt(n[1], 10));
+          e = (_tmpPlural = n.toString().match(/^\d+e(\d+)$/), _tmpPlural === null ? 0 : parseInt(_tmpPlural[1], 10));
         if (typeof n === 'string') n = parseInt(n, 10);
         if (i === 0 || i === 1) return 'one';
         if (e === 0 && (!(i === 0) && (i % 1000000 === 0 && v === 0)) || !(e >= 0 && e <= 5)) return 'many';

--- a/test/CldrPluralRuleSet.js
+++ b/test/CldrPluralRuleSet.js
@@ -26,7 +26,7 @@ describe('CldrPluralRuleSet', () => {
               params: [
                 {
                   type: 'Identifier',
-                  name: 'n',
+                  name: 'val',
                 },
               ],
               body: {
@@ -45,15 +45,17 @@ describe('CldrPluralRuleSet', () => {
   );
 
   it('should encode some basic test cases correctly', () => {
-    expect({ one: 'n is 4 or n is not 6' }, 'to encode to', function (n) {
-      /* eslint-disable */
-      if (typeof n === 'string') n = parseInt(n, 10);
+    expect({ one: 'n is 4 or n is not 6' }, 'to encode to', function (val) {
+      const n = Number(val);
+      if (isNaN(n)) throw Error('n is not a number');
       if (n === 4 || n !== 6) return 'one';
       return 'other';
       /* eslint-enable */
     });
 
-    expect({}, 'to encode to', function (n) {
+    expect({}, 'to encode to', function (val) {
+      const n = Number(val);
+      if (isNaN(n)) throw Error('n is not a number');
       return 'other';
     });
 
@@ -64,11 +66,12 @@ describe('CldrPluralRuleSet', () => {
         many: 'v = 0 and n != 0..10 and n % 10 = 0',
       },
       'to encode to',
-      function (n) {
+      function (val) {
         /* eslint-disable */
-        const i = Math.floor(Math.abs(n)),
-          v = n.toString().replace(/^[^.]*\.?/, '').length;
-        if (typeof n === 'string') n = parseInt(n, 10);
+        const n = Number(val),
+          i = Math.floor(Math.abs(val)),
+          v = val.toString().replace(/^[^.]*\.?/, '').length;
+        if (isNaN(n)) throw Error('n is not a number');
         if (i === 1 && v === 0) return 'one';
         if (i === 2 && v === 0) return 'two';
         // prettier-ignore
@@ -87,11 +90,12 @@ describe('CldrPluralRuleSet', () => {
           ' @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0, 2.0~3.4, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …',
       },
       'to encode to',
-      function (n) {
+      function (val) {
         /* eslint-disable */
-        const i = Math.floor(Math.abs(n)),
-          t = parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
-        if (typeof n === 'string') n = parseInt(n, 10);
+        const n = Number(val),
+          i = Math.floor(Math.abs(val)),
+          t = parseInt(val.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
+        if (isNaN(n)) throw Error('n is not a number');
         if (n === 1 || (!(t === 0) && (i === 0 || i === 1))) return 'one';
         return 'other';
         /* eslint-enable */
@@ -109,11 +113,12 @@ describe('CldrPluralRuleSet', () => {
       },
       'to encode to',
       // prettier-ignore
-      function(n) {
+      function (val) {
         /* eslint-disable */
-        const v = n.toString().replace(/^[^.]*\.?/, '').length,
-          f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
-        if (typeof n === 'string') n = parseInt(n, 10);
+        const n = Number(val),
+          v = val.toString().replace(/^[^.]*\.?/, '').length,
+          f = parseInt(val.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
+          if (isNaN(n)) throw Error('n is not a number');
         if (
           n % 10 === 0 ||
           ((n % 100 === Math.floor(n % 100) &&
@@ -145,13 +150,13 @@ describe('CldrPluralRuleSet', () => {
       },
       'to encode to',
       // prettier-ignore
-      function (n) {
+      function (val) {
         /* eslint-disable */
-        let _tmpPlural;
-        const i = Math.floor(Math.abs(n)),
-          v = n.toString().replace(/^[^.]*\.?/, '').length,
-          e = (_tmpPlural = n.toString().match(/^\d+e(\d+)$/), _tmpPlural === null ? 0 : parseInt(_tmpPlural[1], 10));
-        if (typeof n === 'string') n = parseInt(n, 10);
+        const n = Number(val),
+          i = Math.floor(Math.abs(val)),
+          v = val.toString().replace(/^[^.]*\.?/, '').length,
+          e = parseInt(val.toString().replace(/^[^e]*(e([-+]?\d+))?/, '$2')) || 0;
+          if (isNaN(n)) throw Error('n is not a number');
         if (i === 0 || i === 1) return 'one';
         if (e === 0 && (!(i === 0) && (i % 1000000 === 0 && v === 0)) || !(e >= 0 && e <= 5)) return 'many';
         return 'other';
@@ -170,12 +175,13 @@ describe('CldrPluralRuleSet', () => {
       },
       'to encode to',
       // prettier-ignore
-      function(n) {
+      function (val) {
         /* eslint-disable */
-        const i = Math.floor(Math.abs(n)),
-          v = n.toString().replace(/^[^.]*\.?/, '').length,
-          f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
-        if (typeof n === 'string') n = parseInt(n, 10);
+        const n = Number(val),
+          i = Math.floor(Math.abs(val)),
+          v = val.toString().replace(/^[^.]*\.?/, '').length,
+          f = parseInt(val.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
+          if (isNaN(n)) throw Error('n is not a number');
         if (
           (v === 0 && (i % 10 === 1 && !(i % 100 === 11))) ||
           (f % 10 === 1 && !(f % 100 === 11))

--- a/test/cldrPluralRuleTermFunctionByName.js
+++ b/test/cldrPluralRuleTermFunctionByName.js
@@ -57,6 +57,8 @@ const expectedOutputByTermAndInput = {
     10e10: 0,
     '10e10': 10,
     10: 0,
+    '10e-3': -3,
+    '10e+4': 4,
   },
   c: {
     1: 0,
@@ -65,6 +67,8 @@ const expectedOutputByTermAndInput = {
     10e10: 0,
     '10e10': 10,
     10: 0,
+    '10e-3': -3,
+    '10e+4': 4,
   },
 };
 

--- a/test/extractPluralRuleFunction.js
+++ b/test/extractPluralRuleFunction.js
@@ -8,11 +8,12 @@ describe('extractPluralRuleFunction', () => {
   it('should extract the Romanian plural rule function correctly', () => {
     const romanianPluralRule = cldr.extractPluralRuleFunction('ro');
     // prettier-ignore
-    expect(romanianPluralRule, 'to equal', function anonymous(n) {
+    expect(romanianPluralRule, 'to equal', function anonymous(val) {
       /* eslint-disable */
-      const i = Math.floor(Math.abs(n)),
-        v = n.toString().replace(/^[^.]*\.?/, '').length;
-      if (typeof n === 'string') n = parseInt(n, 10);
+      const n = Number(val),
+        i = Math.floor(Math.abs(val)),
+        v = val.toString().replace(/^[^.]*\.?/, '').length;
+        if (isNaN(n)) throw Error('n is not a number');
       if (i === 1 && v === 0) return 'one';
       if (
         !(v === 0) ||


### PR DESCRIPTION
Recently support for the `e` and `c` operands has been added. Without
realizing, the `n` operand is accidentally overwritten when the operand
variables are initialized. The `n` variable is used as a temporary
accumulator but this variable might be accessed later in the plural
rules, so it's incorrect to change its value.

@papandreou Sorry! Looks like the change wasn't as good as I thought 😄 I realized
that using `n` as a temporary variable could break the use of `n` later in the plural rules.

I'm not sure what you think of this solution. It seems a bit odd to me that the helper variable
is introduced manually through AST. I guess this could be more simpler if the whole function
body is used and evaluated.