### PR TITLE
Adding dayPeriodPatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,28 @@ cldr.extractDayPeriods('en_GB', 'gregorian');
      wide: { am: 'AM', pm: 'PM' } } }
 ```
 
+### cldr.extractDayPeriodRules(localeId='root')
+
+Extract a ruleset for locale-aware day periods,
+to be used with extractDayPeriods().
+
+```javascript
+cldr.extractDayPeriodRules('nl');
+{ format: [
+    { type: 'morning1', at: '', from: '06:00', before: '12:00' },
+    { type: 'afternoon1', at: '', from: '12:00', before: '18:00' },
+    { type: 'evening1', at: '', from: '18:00', before: '24:00' },
+    { type: 'night1', at: '', from: '00:00', before: '06:00' },
+  ],
+  standAlone: [
+    { type: 'midnight', at: '00:00', from: '', before: '' },
+    { type: 'morning1', at: '', from: '06:00', before: '12:00' },
+    { type: 'afternoon1', at: '', from: '12:00', before: '18:00' },
+    { type: 'evening1', at: '', from: '18:00', before: '24:00' },
+    { type: 'night1', at: '', from: '00:00', before: '06:00' }
+  ] }
+```
+
 ### cldr.extractCyclicNames(localeId='root', calendarId='gregorian')
 
 Extract a nested hash with cyclic names for a calendar and locale

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -839,6 +839,7 @@ Cldr.prototype = {
   },
 
   extractDayPeriodRules(localeId) {
+    this.checkValidLocaleId(localeId);
     const document = this.getDocument(
       Path.resolve(this.cldrPath, 'common', 'supplemental', 'dayPeriods.xml'),
     );

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -843,11 +843,11 @@ Cldr.prototype = {
     const document = this.getDocument(
       Path.resolve(this.cldrPath, 'common', 'supplemental', 'dayPeriods.xml'),
     );
-    const dayPeriodRulesNode = xpath.select(
+    const dayPeriodRulesNode = xpath.select1(
       '/supplementalData/dayPeriodRuleSet[not(@type)]' +
         `/dayPeriodRules[@locales='${localeId}']`,
       document,
-    )[0];
+    );
     const dayPeriodRules = xpath.select('dayPeriodRule', dayPeriodRulesNode);
 
     const dayPeriodRulesSelectNode = xpath.select(

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -850,11 +850,11 @@ Cldr.prototype = {
     );
     const dayPeriodRules = xpath.select('dayPeriodRule', dayPeriodRulesNode);
 
-    const dayPeriodRulesSelectNode = xpath.select(
+    const dayPeriodRulesSelectNode = xpath.select1(
       "/supplementalData/dayPeriodRuleSet[@type='selection']" +
         `/dayPeriodRules[@locales='${localeId}']`,
       document,
-    )[0];
+    );
     const dayPeriodSelectsRules = xpath.select(
       'dayPeriodRule',
       dayPeriodRulesSelectNode,

--- a/lib/cldr.js
+++ b/lib/cldr.js
@@ -838,6 +838,46 @@ Cldr.prototype = {
     return dayPeriods;
   },
 
+  extractDayPeriodRules(localeId) {
+    const document = this.getDocument(
+      Path.resolve(this.cldrPath, 'common', 'supplemental', 'dayPeriods.xml'),
+    );
+    const dayPeriodRulesNode = xpath.select(
+      '/supplementalData/dayPeriodRuleSet[not(@type)]' +
+        `/dayPeriodRules[@locales='${localeId}']`,
+      document,
+    )[0];
+    const dayPeriodRules = xpath.select('dayPeriodRule', dayPeriodRulesNode);
+
+    const dayPeriodRulesSelectNode = xpath.select(
+      "/supplementalData/dayPeriodRuleSet[@type='selection']" +
+        `/dayPeriodRules[@locales='${localeId}']`,
+      document,
+    )[0];
+    const dayPeriodSelectsRules = xpath.select(
+      'dayPeriodRule',
+      dayPeriodRulesSelectNode,
+    );
+    return {
+      standAlone: dayPeriodRules.map((dayPeriodRuleNode) => {
+        return {
+          type: dayPeriodRuleNode.getAttribute('type'),
+          at: dayPeriodRuleNode.getAttribute('at'),
+          from: dayPeriodRuleNode.getAttribute('from'),
+          before: dayPeriodRuleNode.getAttribute('before'),
+        };
+      }),
+      format: dayPeriodSelectsRules.map((dayPeriodRuleNode) => {
+        return {
+          type: dayPeriodRuleNode.getAttribute('type'),
+          at: dayPeriodRuleNode.getAttribute('at'),
+          from: dayPeriodRuleNode.getAttribute('from'),
+          before: dayPeriodRuleNode.getAttribute('before'),
+        };
+      }),
+    };
+  },
+
   extractCyclicNames(localeId, calendarId) {
     this.checkValidLocaleId(localeId);
     calendarId = calendarId || 'gregorian';

--- a/test/extractDayPeriodPatterns.js
+++ b/test/extractDayPeriodPatterns.js
@@ -1,0 +1,22 @@
+const expect = require('unexpected');
+
+const cldr = require('../lib/cldr');
+
+describe('extractDayPeriodRules', () => {
+  const dutchDayPeriodRules = cldr.extractDayPeriodRules('nl');
+  it('should have the correct rules', () => {
+    expect(dutchDayPeriodRules.standAlone, 'to equal', [
+      { type: 'midnight', at: '00:00', from: '', before: '' },
+      { type: 'morning1', at: '', from: '06:00', before: '12:00' },
+      { type: 'afternoon1', at: '', from: '12:00', before: '18:00' },
+      { type: 'evening1', at: '', from: '18:00', before: '24:00' },
+      { type: 'night1', at: '', from: '00:00', before: '06:00' },
+    ]);
+    expect(dutchDayPeriodRules.format, 'to equal', [
+      { type: 'morning1', at: '', from: '06:00', before: '12:00' },
+      { type: 'afternoon1', at: '', from: '12:00', before: '18:00' },
+      { type: 'evening1', at: '', from: '18:00', before: '24:00' },
+      { type: 'night1', at: '', from: '00:00', before: '06:00' },
+    ]);
+  });
+});


### PR DESCRIPTION
We had `cldr.extractDayPeriods()`, but no method to extract the [day period patterns](https://www.unicode.org/cldr/charts/46/supplemental/day_periods.html) that they are often used with. Here's an attempt to add that method.